### PR TITLE
ziggurat: make custom-read json not special

### DIFF
--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -1932,7 +1932,6 @@
       ~
     ::
         %custom-read
-      %+  frond  tag.test-step
       %-  pairs
       :~  ['type' %s -.test-step]
           ['tag' %s tag.test-step]

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -611,7 +611,8 @@
     :_  test
     :_  ~
     %-  update-vase-to-card
-    %+  add-custom-error  [`@ux`(sham test) tag]
+    %+  add-custom-error(level %warning)
+      [`@ux`(sham test) tag]
     (crip "file {<`path`p>} not found")
   =/  file-cord=@t  .^(@t %cx file-scry-path)
   =/  [imports=(list [face=@tas =path]) payload=hoon]


### PR DESCRIPTION
**Problem**:

`custom-read` is displayed differently than every other test-step type.

**Solution**:

Make it not special.