### PR TITLE
ziggurat: improve filesync

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1019,8 +1019,7 @@
               projects
             (~(put by projects) project.act project)
           ==
-      :+  %+  make-watch-for-file-changes:zig-lib
-          project.act  dir.project
+      :+  (make-watch-for-file-changes:zig-lib project.act)
         %-  update-vase-to-card:zig-lib
         %.  dir.project
         %~  dir  make-update-vase:zig-lib
@@ -1544,7 +1543,7 @@
       %-  update-vase-to-card:zig-lib
       %~  cis-setup-done  make-update-vase:zig-lib
       [desk %cis-setup-done ~]
-    ~
+    (sync-all-desks-cards:zig-lib sync-desk-to-vship)
   ==
 ::
 ++  on-arvo
@@ -1583,12 +1582,22 @@
     `this
   ::
       [%clay @ ~]
-    ?>  ?=([%clay %wris *] sign-arvo)
+    ?>  ?=([%clay %writ *] sign-arvo)
     =*  project-name  i.t.w
     =/  =project:zig  (~(got by projects) project-name)
+    ?~  p.sign-arvo
+      :_  this
+      :_  ~
+      (make-watch-for-file-changes:zig-lib project-name)
     =/  updated-files=(set path)
-      %-  ~(gas in *(set path))
-      (turn ~(tap in q.sign-arvo) |=([@ p=path] p))
+      =+  !<(=dome:clay q.r.u.p.sign-arvo)
+      =/  =tako:clay  (~(got by hit.dome) let.dome)
+      =+  .^  =yaki:clay
+              %cs
+              %+  weld  /(scot %p our.bowl)/[project-name]
+              /(scot %da now.bowl)/yaki/(scot %uv tako)
+          ==
+      ~(key by q.yaki)
     :_  this
     :-  ?:  .=  0
             %~  wyt  in

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -41,13 +41,10 @@
   !>(`action:zig`project-name^request-id^[%compile-contracts ~])
 ::
 ++  make-watch-for-file-changes
-  |=  [project-name=@tas files=(list path)]
+  |=  project-name=@tas
   ^-  card
   %-  ~(warp-our pass:io /clay/[project-name])
-  :-  project-name
-  :^  ~  %mult  da+now.bowl
-  %-  ~(gas in *(set [care:clay path]))
-  (turn files |=(p=path [%x p]))
+  [project-name ~ %next %v da+now.bowl /]
 ::
 ++  make-cancel-watch-for-file-changes
   |=  project-name=@tas
@@ -758,6 +755,15 @@
       :-  (scot %p our.bowl)
       /pyro/[now]/i/[who]/gu/[who]/[app]/[now]/noun
   ==
+::
+++  sync-all-desks-cards
+  |=  =sync-desk-to-vship:zig
+  ^-  (list card)
+  %-  zing
+  %+  turn  ~(tap by sync-desk-to-vship)
+  |=  [desk=@tas whos=(set @p)]
+  %+  turn  ~(tap in whos)
+  |=(who=@p (sync-desk-to-virtualship-card who desk))
 ::
 ++  sync-desk-to-virtualship-card
   |=  [who=@p project-name=@tas]


### PR DESCRIPTION
**Problem**:

Only modifying files causes a desk sync to vship; when a new desk is added, existing desks are not synced.

**Solution**:

Get us significantly closer to goal of "devship desk state is vship desk state" by:
1. sync whenever there is a change in desk (including add or remove file, as opposed to old behavior which only noticed modifications)
2. sync newly loaded state (e.g. when adding a %new-project) to current devship desk state

**Notes**:

There are two things going on in this PR (1&2 in "Solution" section). To accomplish 1, we use a [%v clay scry](https://developers.urbit.org/reference/arvo/clay/scry#v---desk-state) instead of watching all existing files -- the rest is just parsing out the update from clay.

To accomplish 2, we `+sync-all-desks-cards` at end of `+cis-setup-done`.

FYI @tadad 