### PR TITLE
ziggurat: update agent state using gall surgery + typed scry

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1406,6 +1406,30 @@
       %.  [(show-agent-state:zig-lib agent-state) wex sup]
       %~  shown-pyro-agent-state  make-update-vase:zig-lib
       ['' %pyro-agent-state ~]
+    ::
+        %update-agent-state
+      =/  who=@ta    (scot %p who.act)
+      =*  app        app.act
+      =*  new-state  new-state.act
+      =+  .^  old-agent-state=vase
+              %gx
+              :^  (scot %p our.bowl)  %pyro
+                (scot %da now.bowl)
+              /[who]/[app]/dbug/state/noun/noun
+          ==
+      =/  slapped-agent-state=vase
+        (slap !>(..zuse) (ream new-state))  ::  TODO: acceptable subject?
+      =/  new-agent-state=vase
+        [-.old-agent-state +.slapped-agent-state]
+      ::  TODO: how to handle malformed input?
+      ::   This is vitally important since %slap-gall
+      ::   will uncomplainingly accept malformed input
+      ::   and things will not break until we try to use
+      ::   them (e.g. scry out the state).
+      :_  state
+      %+  ~(poke-our pass:io /pyro-poke)  %pyro-action
+      !>  ^-  action:pyro
+      [%slap-gall who.act app new-agent-state]
     ==
   --
 ::

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -2448,6 +2448,7 @@
         [%send-pyro-dojo (ot ~[[%who (se %p)] [%command sa]])]
     ::
         [%pyro-agent-state pyro-agent-state]
+        [%update-agent-state update-agent-state]
     ::
         [%change-focus ul]
         [%add-project-link ul]
@@ -2594,6 +2595,14 @@
     :^    [%who (se %p)]
         [%app (se %tas)]
       [%grab so]
+    ~
+  ::
+  ++  update-agent-state
+    ^-  $-(json [who=@p app=@tas new-state=@t])
+    %-  ot
+    :^    [%who (se %p)]
+        [%app (se %tas)]
+      [%new-state so]
     ~
   --
 --

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -177,6 +177,7 @@
           [%send-pyro-dojo who=@p command=tape]
       ::
           [%pyro-agent-state who=@p app=@tas grab=@t]
+          [%update-agent-state who=@p app=@tas new-state=@t]
       ::
           [%cis-panic ~]
       ==


### PR DESCRIPTION
**Problem**:

To modify the state of an agent, devs must use pokes -- potentially many.

**Solution**:

Use typed scry to get current state, and pass in a modified `@t`.

**Notes**:

TODO: handle malformed user input. Currently, incorrectly modified state will apply to poke without complaint as if successful, and it is only when trying to use it that things break. Some possibilities as to how to better handle malformed input:

1. punt to FE (i.e. have a warning that "malformed input can break your apps"). Seems bad.
2. snapshot -> apply -> scry dbug state -> detect if broken; if yes, reload snapshot and send an error

2 seems OK -- but we will need to be careful to restrict app usage while we are completing the full cycle; it is fragile if users can do actions during the process.