### PR TITLE
ziggurat: add settings (configure error output length)

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -34,7 +34,7 @@
 +*  this  .
     def      ~(. (default-agent this %|) bowl)
     io       ~(. agentio bowl)
-    zig-lib  ~(. ziggurat-lib bowl)
+    zig-lib  ~(. ziggurat-lib bowl settings)
 ::
 ++  on-init
   =/  smart-lib=vase  ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
@@ -70,6 +70,7 @@
         ~
         ~
         [%uninitialized ~]
+        [1.024 10]
     ==
   ==
 ::
@@ -1406,6 +1407,9 @@
       %.  [(show-agent-state:zig-lib agent-state) wex sup]
       %~  shown-pyro-agent-state  make-update-vase:zig-lib
       ['' %pyro-agent-state ~]
+    ::
+        %change-settings
+      `state(settings settings.act)
     ==
   --
 ::
@@ -1824,6 +1828,12 @@
     %.  [agent-state wex sup]
     %~  pyro-agent-state  make-update-vase:zig-lib
     ['' %pyro-agent-state ~]
+  ::
+      [%settings ~]
+    :^  ~  ~  %ziggurat-update
+    %.  settings
+    %~  settings  make-update-vase:zig-lib
+    ['' %settings ~]
   ::
       [%file-exists @ ^]
     =/  des=@ta    i.t.t.p

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -12,7 +12,7 @@
     smart=zig-sys-smart,
     ui-lib=zig-indexer,
     zink=zink-zink
-|_  =bowl:gall
+|_  [=bowl:gall =settings:zig]
 +*  this    .
     io      ~(. agentio bowl)
     strand  strand:spider
@@ -460,7 +460,8 @@
     "fuse-loop error: type definition produces infinite loop\0a"
   ::
       ?(%'- need' %'- have')
-    ?:  (gte 10 (lent raw-wall))  (of-wall:format raw-wall)  ::  TODO: make configurable
+    ?:  (gte compiler-error-num-lines.settings (lent raw-wall))
+      (of-wall:format raw-wall)
     (weld i.raw-wall "\0a<long type elided>\0a")
   ::
       %'-find.$'
@@ -539,7 +540,8 @@
   |=  [success=? expected=@t result=vase]
   =/  res-text=@t  (crip (noah result))
   :+  success  expected
-  ?:  (lte 1.024 (met 3 res-text))  '<elided>'  ::  TODO: unhardcode
+  ?:  (lte test-result-num-characters.settings (met 3 res-text))
+    '<elided>'
   res-text
 ::
 ++  show-agent-state
@@ -1736,6 +1738,12 @@
     ^-  vase
     !>  ^-  update:zig
     [%focused-linked update-info [%& data] ~]
+  ::
+  ++  settings
+    |=  =settings:zig
+    ^-  vase
+    !>  ^-  update:zig
+    [%settings update-info [%& settings] ~]
   --
 ::
 ++  make-error-vase
@@ -1976,7 +1984,20 @@
     ::
         %save-file
       ['data' (path p.payload.update)]~
+    ::
+        %settings
+      ['data' (settings p.payload.update)]~
     ==
+  ::
+  ++  settings
+    |=  s=settings:zig
+    ^-  json
+    %-  pairs
+    :+  :-  %test-result-num-characters
+        (numb test-result-num-characters.s)
+      :-  %compiler-error-num-lines
+      (numb compiler-error-num-lines.s)
+    ~
   ::
   ++  linked-projects
     |=  linked-projects=(jug @t @t)

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -2475,7 +2475,16 @@
         [%delete-project-link ul]
     ::
         [%cis-panic ul]
+    ::
+        [%change-settings change-settings]
     ==
+  ::
+  ++  change-setings
+    ^-  $-(json settings:zig)
+    %-  ot
+    :+  [%test-result-num-characters ni]
+      [%compiler-error-num-lines ni]
+    ~
   ::
   ++  docket
     ^-  $-(json [@t @t @ux @t [@ud @ud @ud] @t @t])

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -15,6 +15,7 @@
       unfocused-project-snaps=(map (set @t) path)
       test-queue=(qeu [project=@t test-id=@ux])
       =status
+      =settings
   ==
 +$  inflated-state-0
   $:  state-0
@@ -23,6 +24,11 @@
       =ca-scry-cache
   ==
 +$  eng  $_  ~(engine engine:engine-lib !>(0) *(map * @) %.n %.n)  ::  sigs off, hints off
+::
++$  settings
+  $:  test-result-num-characters=@ud
+      compiler-error-num-lines=@ud
+  ==
 ::
 +$  status
   $%  [%running-test-steps ~]
@@ -179,6 +185,8 @@
           [%pyro-agent-state who=@p app=@tas grab=@t]
       ::
           [%cis-panic ~]
+      ::
+          [%change-settings =settings]
       ==
   ==
 ::
@@ -212,6 +220,7 @@
       %status
       %focused-linked
       %save-file
+      %settings
   ==
 +$  update-level  ?(%success error-level)
 +$  error-level   ?(%info %warning %error)
@@ -256,6 +265,7 @@
       [%status update-info payload=(data status) ~]
       [%focused-linked update-info payload=(data focused-linked-data) ~]
       [%save-file update-info payload=(data path) ~]
+      [%settings update-info payload=(data settings) ~]
   ==
 ::
 +$  shown-projects  (map @t shown-project)

--- a/ted/ziggurat/test/run.hoon
+++ b/ted/ziggurat/test/run.hoon
@@ -3,7 +3,7 @@
     zig=zig-ziggurat
 /+  strandio,
     pyro-lib=pyro-pyro,
-    zig-lib=zig-ziggurat
+    ziggurat-lib=zig-ziggurat
 ::
 =*  strand     strand:spider
 =*  get-bowl   get-bowl:strandio
@@ -16,6 +16,8 @@
 ::
 =/  m  (strand ,vase)
 =|  subject=vase
+=|  =settings:zig
+=*  zig-lib  ~(. ziggurat-lib *bowl:gall settings)
 |^  ted
 ::
 +$  arg-mold
@@ -25,6 +27,21 @@
       subject=vase
       snapshot-ships=(list @p)
   ==
+::
+++  get-settings
+  |=  =bowl:spider
+  ^-  settings:zig
+  =+  .^  =update:zig
+          %gx
+          :-  (scot %p our.bowl)
+          /ziggurat/(scot %da now.bowl)/settings/noun
+      ==
+  ?.  ?&  ?=(^ update)
+          ?=(%settings -.update)
+          ?=(%& -.payload.update)
+      ==
+    *settings:zig
+  p.payload.update
 ::
 ++  test-results-of-reads-to-test-result
   |=  trs=test-results:zig
@@ -357,6 +374,7 @@
   ?~  test-steps  (pure:m [%& (flop test-results)])
   =*  test-step   i.test-steps
   ;<  =bowl:strand  bind:m  get-bowl
+  =.  settings  (get-settings bowl)
   ?-    -.test-step
       %wait
     ;<  ~  bind:m  (sleep until.test-step)


### PR DESCRIPTION
**Problem**:

Long outputs are elided -- which is good in general, but bad when, e.g., user wants to scry for a long output.

**Solution**:

Allow user to set by adding `settings` state with same defaults as currently.

**Notes**:

Use `%change-settings` to change the settings and `/settings` to scry out current state.