### PR TITLE
ziggurat: add %unregister-contract-for-compilation

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -838,6 +838,14 @@
           [project request-id]:act
       state(projects (~(put by projects) project.act project))
     ::
+        %unregister-contract-for-compilation
+      =/  =project:zig  (~(got by projects) project.act)
+      ?:  (~(has in to-compile.project) file.act)  `state
+      =.  to-compile.project
+        (~(del in to-compile.project) file.act)
+      :-  ~
+      state(projects (~(put by projects) project.act project))
+    ::
         %deploy-contract
       =/  =project:zig  (~(got by projects) project.act)
       =/  add-test-error

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -2427,6 +2427,7 @@
         [%delete-file (ot ~[[%file pa]])]
     ::
         [%register-contract-for-compilation (ot ~[[%file pa]])]
+        [%unregister-contract-for-compilation (ot ~[[%file pa]])]
         [%deploy-contract deploy]
     ::
         [%compile-contracts ul]

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -144,6 +144,7 @@
           [%delete-config who=@p what=@tas]
       ::
           [%register-contract-for-compilation file=path]
+          [%unregister-contract-for-compilation file=path]
           [%deploy-contract town-id=@ux =path]
       ::
           [%compile-contracts ~]


### PR DESCRIPTION
**Problem**:

Can register but cannot un-register a contract for compilation.

**Solution**:

Add an %unregister poke.

**Notes**:

None