### PR TITLE
ziggurat: change and make more flexible scrying pyro chain state

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -4,6 +4,7 @@
 ::
 /-  spider,
     pyro=zig-pyro,
+    ui=zig-indexer,
     zig=zig-ziggurat,
     zink=zig-zink
 /+  agentio,
@@ -1755,8 +1756,8 @@
     !>  ^-  update:zig
     ?~  project  ~
     :^  %pyro-chain-state  [project-name %pyro-chain-state ~]
-      [%& ~]
-    (get-state:zig-lib project-name u.project configs)
+      [%& (get-state:zig-lib project-name u.project configs)]
+    ~
   ::
       [%test-queue ~]
     :^  ~  ~  %ziggurat-update

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -71,7 +71,7 @@
         ~
         ~
         [%uninitialized ~]
-        [1.024 10]
+        [1.024 10.000 10]
     ==
   ==
 ::
@@ -1415,9 +1415,29 @@
       :_  state
       :_  ~
       %-  update-vase-to-card:zig-lib
-      %.  [(show-agent-state:zig-lib agent-state) wex sup]
+      %.  [(show-state:zig-lib agent-state) wex sup]
       %~  shown-pyro-agent-state  make-update-vase:zig-lib
-      ['' %pyro-agent-state ~]
+      update-info
+    ::
+        %pyro-chain-state
+      =?  grab.act  =('' grab.act)  '-'
+      ::  %shown-pyro-chain-state over %pyro-chain-state
+      ::   because there are casts deep in vanes that don't
+      ::   take too kindly to vases within vases: ideally
+      ::   this should be a %pyro-agent-state like the scry
+      =/  =project:zig  (~(got by projects) project.act)
+      =/  chain-state=(map @ux batch:ui)
+        (get-state:zig-lib project.act project configs)
+      =/  modified-state=vase
+        %-  slap  :_  (ream grab.act)
+        %+  slop  !>(`(map @ux batch:ui)`chain-state)
+        !>([bowl=bowl ..zuse])
+      :_  state
+      :_  ~
+      %-  update-vase-to-card:zig-lib
+      %.  (show-state:zig-lib modified-state)
+      %~  shown-pyro-chain-state  make-update-vase:zig-lib
+      update-info
     ::
         %change-settings
       `state(settings settings.act)
@@ -1727,14 +1747,15 @@
     %.  u.project
     ~(project make-update-vase:zig-lib [project-name %project ~])
   ::
-      [%state @ ~]
+      [%pyro-chain-state @ ~]
     =*  project-name  i.t.t.p
     =/  project=(unit project:zig)
       (~(get by projects) project-name)
     :^  ~  ~  %ziggurat-update
     !>  ^-  update:zig
     ?~  project  ~
-    :^  %state  [project-name %state ~]  [%& ~]
+    :^  %pyro-chain-state  [project-name %pyro-chain-state ~]
+      [%& ~]
     (get-state:zig-lib project-name u.project configs)
   ::
       [%test-queue ~]

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1392,23 +1392,33 @@
         %pyro-agent-state
       =/  who=@ta  (scot %p who.act)
       =*  app      app.act
-      =*  grab     grab.act
-      =?  grab  =('' grab)  '-'
+      =?  grab.act  =('' grab.act)  '-'
       =/  now=@ta  (scot %da now.bowl)
-      =+  .^  agent-state=vase
-              %gx
-              :+  (scot %p our.bowl)  %pyro
-              /[now]/[who]/[app]/dbug/state/noun/noun
-          ==
-      =.  agent-state
-        %-  slap  :_  (ream grab)
-        (slop agent-state !>([bowl=bowl ..zuse]))
       =/  [wex=boat:gall sup=bitt:gall]
         .^  [boat:gall bitt:gall]
             %gx
             :+  (scot %p our.bowl)  %pyro
             /[now]/[who]/[app]/dbug/subscriptions/noun/noun
         ==
+      =+  .^  agent-state=vase
+              %gx
+              :+  (scot %p our.bowl)  %pyro
+              /[now]/[who]/[app]/dbug/state/noun/noun
+          ==
+      =^  subject=(each vase @t)  state
+        %^  compile-imports:zig-lib  `@tas`project.act
+        ~(tap by test-imports.act)  state
+      ?:  ?=(%| -.subject)
+        :_  state
+        :_  ~
+        %-  update-vase-to-card:zig-lib
+        %-  %~  pyro-agent-state  make-error-vase:zig-lib
+            [update-info %error]
+        %^  cat  3  'compilation of test-imports failed:\0a'
+        p.subject
+      =.  p.subject
+        (slop agent-state (slop !>(bowl=bowl) p.subject))
+      =/  modified-state=vase  (slap p.subject (ream grab.act))
       ::  %shown-pyro-agent-state over %pyro-agent-state
       ::   because there are casts deep in vanes that don't
       ::   take too kindly to vases within vases: ideally
@@ -1416,7 +1426,7 @@
       :_  state
       :_  ~
       %-  update-vase-to-card:zig-lib
-      %.  [(show-state:zig-lib agent-state) wex sup]
+      %.  [(show-state:zig-lib modified-state) wex sup]
       %~  shown-pyro-agent-state  make-update-vase:zig-lib
       update-info
     ::
@@ -1429,10 +1439,20 @@
       =/  =project:zig  (~(got by projects) project.act)
       =/  chain-state=(map @ux batch:ui)
         (get-state:zig-lib project.act project configs)
-      =/  modified-state=vase
-        %-  slap  :_  (ream grab.act)
-        %+  slop  !>(`(map @ux batch:ui)`chain-state)
-        !>([bowl=bowl ..zuse])
+      =^  subject=(each vase @t)  state
+        %^  compile-imports:zig-lib  `@tas`project.act
+        ~(tap by test-imports.act)  state
+      ?:  ?=(%| -.subject)
+        :_  state
+        :_  ~
+        %-  update-vase-to-card:zig-lib
+        %-  %~  pyro-chain-state  make-error-vase:zig-lib
+            [update-info %error]
+        %^  cat  3  'compilation of test-imports failed:\0a'
+        p.subject
+      =.  p.subject
+        (slop !>(chain-state) (slop !>(bowl=bowl) p.subject))
+      =/  modified-state=vase  (slap p.subject (ream grab.act))
       :_  state
       :_  ~
       %-  update-vase-to-card:zig-lib

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -989,13 +989,30 @@
           state=inflated-state-0:zig
       ==
   ^-  [(each vase @t) inflated-state-0:zig]
+  =^  subject=(each vase @t)  state
+    (compile-imports project-desk imports state)
+  :_  state
+  ?:  ?=(%| -.subject)  subject
+  =/  initial-test-globals=vase
+    !>  ^-  test-globals:zig
+    :^  our.bowl  now.bowl  *test-results:zig
+    [project-desk configs:state]
+  :-  %&
+  %+  slop
+    %=  initial-test-globals
+      p  [%face %test-globals p.initial-test-globals]
+    ==
+  p.subject
+::
+++  compile-imports
+  |=  $:  project-desk=@tas
+          imports=(list [face=@tas =path])
+          state=inflated-state-0:zig
+      ==
+  ^-  [(each vase @t) inflated-state-0:zig]
   =/  compilation-result
     %-  mule
     |.
-    =/  initial-test-globals=vase
-      !>  ^-  test-globals:zig
-      :^  our.bowl  now.bowl  *test-results:zig
-      [project-desk configs:state]
     =/  [subject=vase c=ca-scry-cache:zig]
       %+  roll  imports
       |:  [[face=`@tas`%$ sur=`path`/] [subject=`vase`!>(..zuse) ca-scry-cache=ca-scry-cache:state]]
@@ -1008,12 +1025,7 @@
       :_  ca-scry-cache
       %-  slop  :_  subject
       sur-hoon(p [%face face p.sur-hoon])
-    :_  c
-    %+  slop
-      %=  initial-test-globals
-        p  [%face %test-globals p.initial-test-globals]
-      ==
-    subject
+    [subject c]
   ?:  ?=(%& -.compilation-result)
     :-  [%& -.p.compilation-result]
     state(ca-scry-cache +.p.compilation-result)
@@ -1814,6 +1826,12 @@
     [%sync-desk-to-vship update-info [%| level message] ~]
   ::
   ++  pyro-agent-state
+    |=  message=@t
+    ^-  vase
+    !>  ^-  update:zig
+    [%pyro-agent-state update-info [%| level message] ~]
+  ::
+  ++  pyro-chain-state
     |=  message=@t
     ^-  vase
     !>  ^-  update:zig
@@ -2645,15 +2663,16 @@
     ~
   ::
   ++  pyro-agent-state
-    ^-  $-(json [who=@p app=@tas grab=@t])
+    ^-  $-(json [who=@p app=@tas =test-imports:zig grab=@t])
     %-  ot
-    :^    [%who (se %p)]
+    :~  [%who (se %p)]
         [%app (se %tas)]
-      [%grab so]
-    ~
+        [%test-imports (om pa)]
+        [%grab so]
+    ==
   ::
   ++  pyro-chain-state
-    ^-  $-(json grab=@t)
-    (ot [%grab so]~)
+    ^-  $-(json [=test-imports:zig grab=@t])
+    (ot ~[[%test-imports (om pa)] [%grab so]])
   --
 --

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -1712,7 +1712,7 @@
     |=  state=(map @ux batch:ui)
     ^-  vase
     !>  ^-  update:zig
-    [%pyro-chain-state update-info [%& state]]
+    [%pyro-chain-state update-info [%& state] ~]
   ::
   ++  shown-pyro-chain-state
     |=  chain-state=@t
@@ -2503,7 +2503,8 @@
   ++  change-settings
     ^-  $-(json settings:zig)
     %-  ot
-    :+  [%test-result-num-characters ni]
+    :^    [%test-result-num-characters ni]
+        [%state-num-characters ni]
       [%compiler-error-num-lines ni]
     ~
   ::
@@ -2652,7 +2653,7 @@
     ~
   ::
   ++  pyro-chain-state
-    ^-  $-(json [who=@p app=@tas grab=@t])
+    ^-  $-(json grab=@t)
     (ot [%grab so]~)
   --
 --

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -1,5 +1,6 @@
 /-  docket,
     engine=zig-engine,
+    ui=zig-indexer,
     wallet=zig-wallet,
     zink=zig-zink
 /+  engine-lib=zig-sys-engine,
@@ -28,6 +29,7 @@
 ::
 +$  settings
   $:  test-result-num-characters=@ud
+      state-num-characters=@ud
       compiler-error-num-lines=@ud
   ==
 ::
@@ -187,6 +189,7 @@
           [%send-pyro-dojo who=@p command=tape]
       ::
           [%pyro-agent-state who=@p app=@tas grab=@t]
+          [%pyro-chain-state grab=@t]
       ::
           [%cis-panic ~]
       ::
@@ -200,7 +203,6 @@
   $?  %project-names
       %projects
       %project
-      %state
       %new-project
       %add-config
       %delete-config
@@ -219,6 +221,9 @@
       %poke
       %test-queue
       %pyro-agent-state
+      %shown-pyro-agent-state
+      %pyro-chain-state
+      %shown-pyro-chain-state
       %sync-desk-to-vship
       %cis-setup-done
       %status
@@ -244,7 +249,6 @@
   $%  [%project-names update-info payload=(data ~) project-names=(set @t)]
       [%projects update-info payload=(data ~) projects=shown-projects]
       [%project update-info payload=(data ~) shown-project]
-      [%state update-info payload=(data ~) state=(map @ux chain:engine)]
       [%new-project update-info payload=(data =sync-desk-to-vship) ~]
       [%add-config update-info payload=(data [who=@p what=@tas item=@]) ~]
       [%delete-config update-info payload=(data [who=@p what=@tas]) ~]
@@ -264,6 +268,8 @@
       [%test-queue update-info payload=(data (qeu [@t @ux])) ~]
       [%pyro-agent-state update-info payload=(data [agent-state=vase wex=boat:gall sup=bitt:gall]) ~]
       [%shown-pyro-agent-state update-info payload=(data [agent-state=@t wex=boat:gall sup=bitt:gall]) ~]
+      [%pyro-chain-state update-info payload=(data (map @ux batch:ui)) ~]
+      [%shown-pyro-chain-state update-info payload=(data @t) ~]
       [%sync-desk-to-vship update-info payload=(data sync-desk-to-vship) ~]
       [%cis-setup-done update-info payload=(data ~) ~]
       [%status update-info payload=(data status) ~]

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -188,8 +188,8 @@
       ::
           [%send-pyro-dojo who=@p command=tape]
       ::
-          [%pyro-agent-state who=@p app=@tas grab=@t]
-          [%pyro-chain-state grab=@t]
+          [%pyro-agent-state who=@p app=@tas =test-imports grab=@t]
+          [%pyro-chain-state =test-imports grab=@t]
       ::
           [%cis-panic ~]
       ::


### PR DESCRIPTION
**Problem**:

1. Chain state scrying only gives state.
2. Can't manipulate that data (which is often big). 

**Solution**:

1. Scry now returns tx.s as well. 
2. Add poke similar to %pyro-agent-state with `grab` field.

**Notes**:

FYI @0x70b1a5 see new interface

~~WIP~~