### PR TITLE
ziggurat: default state views

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1890,6 +1890,19 @@
     %~  settings  make-update-vase:zig-lib
     ['' %settings ~]
   ::
+      [%state-views @ ~]
+    =*  project-name  i.t.t.p
+    =*  update-info  [project-name %state-views ~]
+    =/  [* cfo=(unit configuration-file-output:zig) *]
+      (load-configuration-file:zig-lib update-info state)
+    :^  ~  ~  %json
+    !>  ^-  json
+    ?~  cfo  ~
+    %-  update:enjs:zig-lib
+    !<  update:zig
+    %.  state-views.u.cfo
+    %~  state-views  make-update-vase:zig-lib  update-info
+  ::
       [%file-exists @ ^]
     =/  des=@ta    i.t.t.p
     =/  pat=path  `path`t.t.t.p

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1407,7 +1407,7 @@
               /[now]/[who]/[app]/dbug/state/noun/noun
           ==
       =^  subject=(each vase @t)  state
-        %^  compile-imports:zig-lib  `@tas`project.act
+        %^  compile-test-imports:zig-lib  `@tas`project.act
         ~(tap by test-imports.act)  state
       ?:  ?=(%| -.subject)
         :_  state
@@ -1440,7 +1440,7 @@
       =/  chain-state=(map @ux batch:ui)
         (get-chain-state:zig-lib project.act configs)
       =^  subject=(each vase @t)  state
-        %^  compile-imports:zig-lib  `@tas`project.act
+        %^  compile-test-imports:zig-lib  `@tas`project.act
         ~(tap by test-imports.act)  state
       ?:  ?=(%| -.subject)
         :_  state

--- a/lib/zink/conq.hoon
+++ b/lib/zink/conq.hoon
@@ -252,4 +252,38 @@
     ;~(plug (stag ~ sym) ;~(pfix tis sym))
     (cook |=(a=term [`a a]) sym)
   ==
+::
+::  abbreviated parser from lib/zink/conq.hoon:
+::   parse to end of imports, start of hoon.
+::   used to find start of hoon for compilation and to find
+::   proper line error number in case of error
+::   (see +mule-slap-subject)
+::
++$  small-start-of-pile  (list [face=term =path])
+::
+++  parse-start-of-pile
+  |=  tex=tape
+  ^-  [small-start-of-pile hair]
+  =/  [=hair res=(unit [=small-start-of-pile =nail])]
+    (start-of-pile-rule [1 1] tex)
+  ?^  res  [small-start-of-pile.u.res hair]
+  %-  mean  %-  flop
+  =/  lyn  p.hair
+  =/  col  q.hair
+  :~  leaf+"syntax error"
+      leaf+"\{{<lyn>} {<col>}}"
+      leaf+(runt [(dec col) '-'] "^")
+      leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
+  ==
+::
+++  start-of-pile-rule
+  %+  ifix
+    :_  gay
+    ::  parse optional smart library import and ignore
+    ;~(plug gay (punt ;~(plug fas lus gap taut-rule:conq gap)))
+  ;~  plug
+  ::  only accept /= imports for contract libraries
+    %+  rune:conq  tis
+    ;~(plug sym ;~(pfix gap stap))
+  ==
 --

--- a/readme.md
+++ b/readme.md
@@ -320,10 +320,11 @@ The configuration file has a specified form.
 Imports may be specified using the `/=` rune at the top of the file.
 The file is then composed of a core with the following arms:
 
-Arm name                     | Return type               | Description
----------------------------- | ------------------------- | -----------
-`+make-config`               | `config:zig`              | Set global state for the project, accessible during `test-steps`.
-`+make-virtualships-to-sync` | `(list @p)`               | Set `%pyro` ships to mirror the project desk on.
-`+make-install`              | `?`                       | Install the mirrored desk on synced `%pyro` ships?
-`+make-start-apps`           | `(list @tas)`             | Additionaly apps to start in the project on synced `%pyro` ships (that are not included in the project's `desk.bill`).
-`+make-setup`                | `(map @p test-steps:zig)` | Set the initial state on synced `%pyro` ships by running these `test-steps`.
+Arm name                     | Return type                                      | Description
+---------------------------- | ------------------------------------------------ | -----------
+`+make-config`               | `config:zig`                                     | Set global state for the project, accessible during `test-steps`.
+`+make-virtualships-to-sync` | `(list @p)`                                      | Set `%pyro` ships to mirror the project desk on.
+`+make-install`              | `?`                                              | Install the mirrored desk on synced `%pyro` ships?
+`+make-start-apps`           | `(list @tas)`                                    | Additional apps to start on synced `%pyro` ships (that are not included in the project's `desk.bill`).
+`+make-state-views`          | `(list [who=@p app=(unit @tas) file-path=path])` | Default state views, specified in the file path. `app=~` -> chain view, not an agent view.
+`+make-setup`                | `(map @p test-steps:zig)`                        | Set the initial state on synced `%pyro` ships by running these `test-steps`.

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -115,6 +115,7 @@
       ships=(list @p)
       install=?
       start=(list @tas)
+      state-views=(list [who=@p app=(unit @tas) file=path])
       setup=(map @p test-steps)
       imports=(list [@tas path])
   ==
@@ -231,6 +232,7 @@
       %focused-linked
       %save-file
       %settings
+      %state-views
   ==
 +$  update-level  ?(%success error-level)
 +$  error-level   ?(%info %warning %error)
@@ -277,6 +279,7 @@
       [%focused-linked update-info payload=(data focused-linked-data) ~]
       [%save-file update-info payload=(data path) ~]
       [%settings update-info payload=(data settings) ~]
+      [%state-views update-info payload=(data (list [@p (unit @tas) path])) ~]
   ==
 ::
 +$  shown-projects  (map @t shown-project)

--- a/zig/configs/zig.hoon
+++ b/zig/configs/zig.hoon
@@ -20,6 +20,19 @@
   ^-  (list @tas)
   ~[%subscriber]
 ::
+++  make-state-views
+  ^-  (list [who=@p app=(unit @tas) file-path=path])
+  ::  app=~ -> chain view, not an agent view
+  =/  pfix  (cury welp `path`/zig/state-views)
+  :~  [~nec ~ (pfix /chain/transactions/hoon)]
+      [~nec ~ (pfix /chain/chain/hoon)]
+      [~nec ~ (pfix /chain/holder-our/hoon)]
+      [~nec ~ (pfix /chain/source-zigs/hoon)]
+  ::
+      [~nec `%wallet (pfix /agent/wallet-metadata-store/hoon)]
+      [~nec `%wallet (pfix /agent/wallet-our-items/hoon)]
+  ==
+::
 ++  make-setup
   |^  ^-  (map @p test-steps:zig)
   %-  ~(gas by *(map @p test-steps:zig))

--- a/zig/state-views/agent/wallet-metadata-store.hoon
+++ b/zig/state-views/agent/wallet-metadata-store.hoon
@@ -1,0 +1,1 @@
+metadata-store

--- a/zig/state-views/agent/wallet-our-items.hoon
+++ b/zig/state-views/agent/wallet-our-items.hoon
@@ -1,0 +1,9 @@
+/=  wal  /sur/zig/wallet
+::
+::  get our held items
+^-  (map @ux book:wal)
+=/  who=@p  our:test-globals
+=/  who-address=@ux
+  %.  [%global [who %address]
+  ~(got bi:mip configs:test-globals)
+(~(got by tokens) who-address)

--- a/zig/state-views/chain/chain.hoon
+++ b/zig/state-views/chain/chain.hoon
@@ -1,0 +1,1 @@
+chain:(~(got by -) 0x0)

--- a/zig/state-views/chain/holder-our.hoon
+++ b/zig/state-views/chain/holder-our.hoon
@@ -1,0 +1,21 @@
+/=  mip    /lib/mip
+/=  smart  /lib/zig/sys/smart
+::
+::  get all our held items
+^-  (map @ux item:smart)
+=/  who=@p  our:test-globals
+=/  who-address=@ux
+  %.  [%global [who %address]
+  ~(got bi:mip configs:test-globals)
+%-  ~(gas by *(map @ux item:smart))
+%+  murn  ~(tap by chain:(~(got by -) 0x0))
+|=  [id=@ux @ =item:smart]
+?-    -.item  ::  dumb pattern to satisfy compiler
+    %&
+  ?.  =(who-address holder.p.item)  ~
+  `[id item]
+::
+    %|
+  ?.  =(who-address holder.p.item)  ~
+  `[id item]
+==

--- a/zig/state-views/chain/source-zigs.hoon
+++ b/zig/state-views/chain/source-zigs.hoon
@@ -1,0 +1,17 @@
+/=  smart  /lib/zig/sys/smart
+::
+::  get all items with contract source=zigs
+^-  (map @ux item:smart)
+=/  source=@ux  0x74.6361.7274.6e6f.632d.7367.697a
+%-  ~(gas by *(map @ux item:smart))
+%+  murn  ~(tap by chain:(~(got by -) 0x0))
+|=  [id=@ux @ =item:smart]
+?-    -.item  ::  dumb pattern to satisfy compiler
+    %&
+  ?.  =(source source.p.item)  ~
+  `[id item]
+::
+    %|
+  ?.  =(source source.p.item)  ~
+  `[id item]
+==

--- a/zig/state-views/chain/transactions.hoon
+++ b/zig/state-views/chain/transactions.hoon
@@ -1,0 +1,1 @@
+transactions:(~(got by -) 0x0)


### PR DESCRIPTION
**Problem**:

We want to enable projects to come with pre-loaded state views.

**Solution**:

Add an additional arm to configuration files.

**Notes**:

When the project is loaded, a %state-views card is sent out. The FE should capture this and use it to populate the new project's state views.

However, since the %zig desk is set up before the FE is running, there is a scry `/state-views/[project-name]` that will return a JSONified %state-views update.