### PR TITLE
ziggurat: add `name` field to `desk`

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -473,7 +473,7 @@
       =/  new-project-error
         %~  new-project  make-error-vase:zig-lib
         [update-info %error]
-      ?:  (~(has by projects) project-name.act)
+      ?:  &((~(has by projects) project-name.act) !=('zig' project-name.act))
         :_  state
         :_  ~
         %-  update-vase-to-card:zig-lib
@@ -562,6 +562,7 @@
       ::
           projects
         =|  =desk:zig
+        =.  name.desk  desk-name.act
         =.  user-files.desk
           (~(put in *(set path)) /app/[project-name.act]/hoon)
         =/  =project:zig
@@ -716,9 +717,10 @@
         (crip "desk {<`@tas`desk-name.act>} does not exist")
       =.  desks.project
         ?~  index.act
-          (snoc desks.project [desk-name.act *desk:zig])
+          %+  snoc  desks.project
+          [desk-name.act desk-name.act +:*desk:zig]
         %^  into  desks.project  u.index.act
-        [desk-name.act *desk:zig]
+        [desk-name.act desk-name.act +:*desk:zig]
       (update-project-from-desk-change update-info project)
     ::
         %delete-project-desk

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -613,7 +613,8 @@
 ++  show-desk
   |=  =desk:zig
   ^-  shown-desk:zig
-  :*  dir=dir.desk
+  :*  name=name.desk
+      dir=dir.desk
       user-files=user-files.desk
       to-compile=to-compile.desk
       tests=(show-tests tests.desk)
@@ -2295,7 +2296,8 @@
     |=  d=desk:zig
     ^-  json
     %-  pairs
-    :~  ['dir' (dir dir.d)]
+    :~  ['name' %s name.d]
+        ['dir' (dir dir.d)]
         ['user_files' (dir ~(tap in user-files.d))]
         ['to_compile' (dir ~(tap in to-compile.d))]
         ['tests' (tests tests.d)]
@@ -2338,7 +2340,8 @@
     |=  d=shown-desk:zig
     ^-  json
     %-  pairs
-    :~  ['dir' (dir dir.d)]
+    :~  ['name' %s name.d]
+        ['dir' (dir dir.d)]
         ['user_files' (dir ~(tap in user-files.d))]
         ['to_compile' (dir ~(tap in to-compile.d))]
         ['tests' (shown-tests tests.d)]

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -48,7 +48,8 @@
       saved-test-queue=(qeu [project-name=@t desk-name=@tas test-id=@ux])
   ==
 +$  desk
-  $:  dir=(list path)
+  $:  name=@tas
+      dir=(list path)
       user-files=(set path)
       to-compile=(set path)
       =tests
@@ -294,7 +295,8 @@
       saved-test-queue=(qeu [project-name=@t desk-name=@tas test-id=@ux])
   ==
 +$  shown-desk
-  $:  dir=(list path)
+  $:  name=@tas
+      dir=(list path)
       user-files=(set path)
       to-compile=(set path)
       tests=shown-tests


### PR DESCRIPTION
**Problem**:

Annoying for FE to deal with `desk` not having `name`.

**Solution**:

Add `name` field to `desk`.