### PR TITLE
ziggurat: fix %new-project for existent desks without config

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1048,7 +1048,13 @@
       =*  project-name  project-name.update-info
       =*  desk-name     desk-name.update-info
       =*  request-id    request-id.update-info
-      =/  cards=(list card)
+      =/  config-file-path=path
+        :-  (scot %p our.bowl)
+        %+  weld  /[desk-name]/(scot %da now.bowl)
+        /ted/ziggurat/configuration/[desk-name]/hoon
+      =/  does-config-exist=?  .^(? %cu config-file-path)
+      ~&  %z^%np^%does-config-exist^does-config-exist
+      ?:  does-config-exist
         :_  ~
         %-  ~(poke-self pass:io /self-wire)
         :-  %ziggurat-action
@@ -1065,13 +1071,32 @@
             !>(request-id)
             special-configuration-args
         ==
-      =/  config-file-path=path
-        :-  (scot %p our.bowl)
-        %+  weld  /[desk-name]/(scot %da now.bowl)
-        /ted/ziggurat/configuration/[desk-name]/hoon
-      =/  does-config-exist=?  .^(? %cu config-file-path)
-      ~&  %z^%np^%does-config-exist^does-config-exist
-      ?:  does-config-exist  cards
+      =/  cards=(list card)
+        :_  ~
+        %-  ~(poke-self pass:io /self-wire)
+        :-  %ziggurat-action
+        !>  ^-  action:zig
+        :^  project-name  desk-name  request-id
+        :^  %queue-thread
+          (cat 3 'ziggurat-configuration-' desk-name)  %lard
+        %:  setup-desk:zig-threads
+            project-name
+            desk-name
+            request-id
+            !>(~)
+            ~
+            ~
+            ~
+            %.n
+            ~
+        ==
+      ?:  %.  desk-name
+          %~  has  in
+          .^  (set @tas)
+              %cd
+              /(scot %p our.bowl)//(scot %da now.bowl)
+          ==
+        cards
       :_  cards
       %-  ~(poke-self pass:io /self-wire)
       :-  %ziggurat-action

--- a/lib/zig/ziggurat/threads.hoon
+++ b/lib/zig/ziggurat/threads.hoon
@@ -436,8 +436,6 @@
   ;<  ~  bind:m  make-mount
   ;<  ~  bind:m  make-bill
   ;<  ~  bind:m  make-deletions
-  :: ;<  ~  bind:m  make-read-desk
-  ;<  ~  bind:m  make-configuration-file
   ;<  ~  bind:m  (sleep ~s1)
   (pure:m !>(~))
   ::


### PR DESCRIPTION
**Problem**:

Running %new-project on a desk that exists but does not have a configuration thread crashes.

**Solution**:

Run +setup-desk rather than creating an empty configuration thread that runs it (and has dependencies that cause crash).

**Notes**:

None.