### PR TITLE
scripts: add fakeship %suite setup script

### DIFF
--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -81,7 +81,7 @@
       %-  ~(gas of *(axal (cask)))
       %+  user-files:pill
         /(scot %p p.byk.bowl)/base/(scot %da now.bowl)
-      ~
+      ~[/scripts]
     =.  park  (park:pyro our.bowl %base %da now.bowl)
     :_  this
     :: poke-our to add base

--- a/mar/sh.hoon
+++ b/mar/sh.hoon
@@ -1,0 +1,12 @@
+|_  sh=@
+++  grow
+  |%
+  ++  mime  [/text/x-shellscript (as-octs:mimes:html (@t sh))]
+  --
+++  grab
+  |%                                                    ::  convert from
+  ++  mime  |=([p=mite q=octs] (@t q.q))
+  ++  noun  cord                                        ::  clam from %noun
+  --
+++  grad  %mime
+--

--- a/scripts/commit-and-install-desks.hoon
+++ b/scripts/commit-and-install-desks.hoon
@@ -1,0 +1,41 @@
+=/  m  (strand ,vase)
+|^  ted
+++  iterate-over-desks
+  =/  m  (strand ,~)
+  |=  [desk-names=(list @tas) gate=$-(@tas form:m)]
+  ^-  form:m
+  |-
+  ?~  desk-names  (pure:m ~)
+  =*  desk-name  i.desk-names
+  ;<  ~  bind:m  (gate desk-name)
+  $(desk-names t.desk-names)
+++  commit-desk
+  |=  desk-name=@tas
+  =/  m  (strand ,~)
+  ^-  form:m
+  ;<  ~  bind:m
+    %-  send-raw-card
+    :^  %pass  /mount/[desk-name]  %arvo  [%c %dirk desk-name]
+  (pure:m ~)
+++  install-desk
+  |=  desk-name=@tas
+  =/  m  (strand ,~)
+  ^-  form:m
+  ;<  =bowl:strand  bind:m  get-bowl
+  ;<  ~  bind:m
+    %+  poke-our  %hood
+    :-  %kiln-install
+    !>([desk-name our.bowl desk-name])
+  (pure:m ~)
+++  ted
+  ^-  form:m
+  =/  commit-desk-names=(list @tas)  ~[%suite %zig %zig-dev]
+  =/  install-desk-names=(list @tas)  ~[%suite]
+  ;<  ~  bind:m
+    (iterate-over-desks commit-desk-names commit-desk)
+  ;<  ~  bind:m  (sleep (mul ~s1 (lent commit-desk-names)))
+  ;<  ~  bind:m
+    (iterate-over-desks install-desk-names install-desk)
+  ;<  ~  bind:m  (sleep ~s1)
+  (pure:m !>('commit-and-install-desks: success'))
+--

--- a/scripts/commit-base.hoon
+++ b/scripts/commit-base.hoon
@@ -1,0 +1,27 @@
+=/  m  (strand ,vase)
+|^  ted
+++  iterate-over-desks
+  =/  m  (strand ,~)
+  |=  [desk-names=(list @tas) gate=$-(@tas form:m)]
+  ^-  form:m
+  |-
+  ?~  desk-names  (pure:m ~)
+  =*  desk-name  i.desk-names
+  ;<  ~  bind:m  (gate desk-name)
+  $(desk-names t.desk-names)
+++  commit-desk
+  |=  desk-name=@tas
+  =/  m  (strand ,~)
+  ^-  form:m
+  ;<  ~  bind:m
+    %-  send-raw-card
+    :^  %pass  /mount/[desk-name]  %arvo  [%c %dirk desk-name]
+  (pure:m ~)
+++  ted
+  ^-  form:m
+  =/  commit-desk-names=(list @tas)  ~[%base]
+  =/  install-desk-names=(list @tas)  ~
+  ;<  ~  bind:m
+    (iterate-over-desks commit-desk-names commit-desk)
+  (pure:m !>('commit-base: success'))
+--

--- a/scripts/create-desks.hoon
+++ b/scripts/create-desks.hoon
@@ -1,0 +1,65 @@
+=/  m  (strand ,vase)
+^-  form:m
+|^  ted
+++  iterate-over-desks
+  =/  m  (strand ,~)
+  |=  [desk-names=(list @tas) gate=$-(@tas form:m)]
+  ^-  form:m
+  |-
+  ?~  desk-names  (pure:m ~)
+  =*  desk-name  i.desk-names
+  ;<  ~  bind:m  (gate desk-name)
+  $(desk-names t.desk-names)
+++  mount-desk
+  |=  desk-name=@tas
+  =/  m  (strand ,~)
+  ^-  form:m
+  ;<  =bowl:strand  bind:m  get-bowl
+  ;<  ~  bind:m
+    %-  send-raw-card
+    :^  %pass  /mount/[desk-name]  %arvo
+    [%c %mont desk-name [our.bowl desk-name da+now.bowl] /]
+  (pure:m ~)
+++  make-new-desk
+  |=  desk-name=@tas
+  =/  m  (strand ,~)
+  ^-  form:m
+  =/  file-paths=(list path)
+    :~  /mar/noun/hoon
+        /mar/hoon/hoon
+        /mar/txt/hoon
+        /mar/kelvin/hoon
+        /sys/kelvin
+    ==
+  =|  path-to-page=(map path page:clay)
+  ;<  =bowl:strand  bind:m  get-bowl
+  =.  path-to-page
+    |-
+    ?~  file-paths  path-to-page
+    =*  p  i.file-paths
+    =+  .^  file=*
+            %cx
+            %-  weld  :_  p
+            /(scot %p our.bowl)/base/(scot %da now.bowl)
+        ==
+    %=  $
+        file-paths  t.file-paths
+        path-to-page
+      (~(put by path-to-page) p [(rear p) file])
+    ==
+  ;<  ~  bind:m
+    %-  send-raw-card
+    :^  %pass  /new-desk/[desk-name]  %arvo
+    %^  new-desk:cloy  desk-name  ~  path-to-page
+  (pure:m ~)
+++  ted
+  ^-  form:m
+  =/  desk-names=(list @tas)  ~[%suite %zig %zig-dev]
+  ;<  ~  bind:m
+    (iterate-over-desks desk-names make-new-desk)
+  ;<  ~  bind:m  (sleep ~s1)
+  ;<  ~  bind:m
+    (iterate-over-desks desk-names mount-desk)
+  ;<  ~  bind:m  (sleep ~s1)
+  (pure:m !>('create-desks: success'))
+--

--- a/scripts/dummy.hoon
+++ b/scripts/dummy.hoon
@@ -1,0 +1,2 @@
+=/  m  (strand ,vase)
+(pure:m !>('dummy: success'))

--- a/scripts/setup-fakeship.sh
+++ b/scripts/setup-fakeship.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+app_name="setup-fakeship"
+usage_string="Usage: ./${app_name}.sh path_to_vere path_to_pier path_to_repos"
+
+if [ $# -ne 3 ] ; then
+  echo "Use this script with a new, running fakeship to setup and install %suite."
+  echo "$usage_string"
+  echo "path_to_vere is the path to the vere binary"
+  echo "path_to_pier is the path to the fakeship pier to setup and install %suite on"
+  echo "path_to_repos is the path to the directory containing urbit and vere repositories (or where they should be cloned to)"
+  exit 1
+fi
+path_to_vere=$(realpath $1)
+path_to_pier=$(realpath $2)
+path_to_repos=$(realpath $3)
+
+path_to_scripts=$(pwd)
+
+if [ ! -e "${path_to_pier}/.run" ]; then
+  $path_to_vere dock $path_to_pier
+fi
+
+cd $path_to_repos
+for repo in urbit vere; do
+  if [ ! -d "$repo" ]; then
+    url="https://github.com/urbit/${repo}.git"
+    echo "cloning ${url} into ${path_to_repos}/${repo} ..."
+    git clone ${url}
+  else
+    cd $repo
+    git checkout master
+    git pull
+    cd ..
+  fi
+done
+path_to_click=$(realpath vere/pkg/click/click)
+
+cd urbit/pkg
+
+for submodule in dev-suite uqbar-core zig-dev; do
+  if [ ! -d "$submodule" ]; then
+    url="https://github.com/uqbar-dao/${submodule}.git"
+    echo "creating submodule ${url} in ${path_to_repos}/urbit/pkg/${submodule} ..."
+    git submodule add ${url}
+  else
+    cd $submodule
+    git checkout master
+    git pull
+    cd ..
+  fi
+done
+
+# TODO: remove once master up to date
+cd dev-suite
+git checkout next/suite
+git pull
+cd ..
+cd uqbar-core
+git checkout hf/ziggurat-refactor-project
+git pull
+cd ..
+
+echo "creating desks ..."
+$path_to_click -k -i ${path_to_scripts}/create-desks.hoon ${path_to_pier}
+
+echo "copying files into desks..."
+for submodule in dev-suite uqbar-core zig-dev; do
+  desk_name=""
+  if [ "dev-suite" = "$submodule" ]; then
+    desk_name="suite"
+  elif [ "uqbar-core" = "$submodule" ]; then
+    desk_name="zig"
+  elif [ "zig-dev" = "$submodule" ]; then
+    desk_name="zig-dev"
+  fi
+
+  rm -rf ${path_to_pier}/${desk_name}/*
+  cp -RL ${path_to_repos}/urbit/pkg/${submodule}/* ${path_to_pier}/${desk_name}/
+done
+
+echo "committing and installing desks ..."
+$path_to_click -k -i ${path_to_scripts}/commit-and-install-desks.hoon ${path_to_pier}
+
+echo "script done. installation will be finished when dojo reads something like:"
+echo "[%pyro %snapshot /zig-dev/~2023.4.12..04.41.46..0b46]"
+exit 0


### PR DESCRIPTION
**Problem**:

It is painful to set up a new fakeship every urbit release.

**Solution**:

Make it somewhat less painful by scripting part of it.

**Notes**:

I'd recommend not pointing this script at your main development repositories because it is new.

Usage example:

```bash
#  make working directory
mkdir ~/urbit-for-suite-testing
cd ~/urbit-for-suite-testing
mkdir git

#  make fakeship
./vere -F zod

#  put /scripts in that directory
#  (assume we now have /scripts dir with the /scripts here found therein)

#  setup fakeship
./setup-fakeship.sh ../zod/ ../git/
```