### PR TITLE
ziggurat: dont crash if state-views file does not exist

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1233,13 +1233,14 @@
     =*  project-desk-name  i.t.t.p
     =*  update-info
       [project-desk-name project-desk-name %state-views ~]
-    =/  =state-views:zig
+    =/  state-views=(unit state-views:zig)
       (make-state-views:zig-lib project-desk-name)
+    ?~  state-views  ``json+!>(~)
     :^  ~  ~  %json
     !>  ^-  json
     %-  update:enjs:zig-lib
     !<  update:zig
-    %.  state-views
+    %.  u.state-views
     %~  state-views  make-update-vase:zig-lib  update-info
   ::
       [%get-smart-lib-vase ~]

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -678,14 +678,13 @@
 ::
 ++  make-state-views
   |=  project-desk-name=@tas
-  ^-  state-views:zig
-  !<  state-views:zig
-  .^  vase
-      %ca
-      :^  (scot %p our.bowl)  project-desk-name
-        (scot %da now.bowl)
-      /zig/state-views/[project-desk-name]/hoon
-  ==
+  ^-  (unit state-views:zig)
+  =*  p
+    :^  (scot %p our.bowl)  project-desk-name
+      (scot %da now.bowl)
+    /zig/state-views/[project-desk-name]/hoon
+  ?.  .^(? %cu p)  ~
+  `!<(state-views:zig .^(vase %ca p))
 ::
 ++  convert-test-steps-to-thread
   |=  $:  project-name=@t

--- a/lib/zig/ziggurat/threads.hoon
+++ b/lib/zig/ziggurat/threads.hoon
@@ -779,26 +779,28 @@
   ~&  %sp^%3
   ;<  ~  bind:m  send-new-project-update
   ~&  %sp^%4
-  ;<  =state-views:zig  bind:m  make-state-views
-  ;<  ~  bind:m
-    %+  poke-our  %ziggurat
-    :-  %ziggurat-action
-    !>  ^-  action:zig
-    :^  project-name  %$  request-id
-    [%send-state-views state-views]
+  ;<  ~  bind:m  send-state-views
   ~&  %sp^%5
   ;<  empty-vase=vase  bind:m
     %-  commit-install-start
     [whos desk-dependency-names install start-apps]
   return-success
   ::
-  ++  make-state-views
-    =/  m  (strand ,state-views:zig)
+  ++  send-state-views
+    =/  m  (strand ,~)
     ^-  form:m
     ;<  =bowl:strand  bind:m  get-bowl
-    %-  pure:m
-    %.  project-name
-    make-state-views:zig-lib(our.bowl our.bowl, now.bowl now.bowl)
+    =/  state-views=(unit state-views:zig)
+      %.  project-name
+      make-state-views:zig-lib(our.bowl our.bowl, now.bowl now.bowl)
+    ?~  state-views  (pure:m ~)
+    ;<  ~  bind:m
+      %+  poke-our  %ziggurat
+      :-  %ziggurat-action
+      !>  ^-  action:zig
+      :^  project-name  %$  request-id
+      [%send-state-views u.state-views]
+    (pure:m ~)
   ::
   ++  get-dependency-desks
     =/  m  (strand ,~)


### PR DESCRIPTION
**Problem**:

Crash on new project with no project desk because we scry for state-views that DNE.

**Solution**:

Check for state-view file existence before attempting to scry out the file contents.

**Notes**:

none