### PR TITLE
ziggurat: build only changed files on commit

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1369,7 +1369,6 @@
 ++  on-agent
   |=  [w=wire =sign:agent:gall]
   ^-  (quip card _this)
-  :: |^
   ?+    w  (on-agent:def w sign)
       [%linedb @ @ @ @ ~]
     ?:  ?=(%watch-ack -.sign)  `this

--- a/ted/ziggurat/build.hoon
+++ b/ted/ziggurat/build.hoon
@@ -37,15 +37,16 @@
   ==
 ::
 ++  return-success
+  |=  result=vase
   =/  m  (strand ,vase)
   ^-  form:m
-  (pure:m !>(`(unit @t)`~))
+  (pure:m !>(`(each vase tang)`[%& result]))
 ::
 ++  return-error
   |=  message=tape
   =/  m  (strand ,vase)
   ^-  form:m
-  (pure:m !>(`(unit @t)``(crip message)))
+  (pure:m !>(`(each vase tang)`[%| [%leaf message]~]))
 ::
 ++  ted
   ^-  thread:spider
@@ -85,7 +86,8 @@
       %-  return-error
       %+  weld  "{<file-path>} build failed unexpectedly,"
       " please see dojo for compilation errors"
-    ?:  ?=(%& -.result.update)  return-success
+    ?:  ?=(%& -.result.update)
+      (return-success p.result.update)
     =*  error
       (reformat-compiler-error:zig-lib p.result.update)
     %-  return-error
@@ -131,5 +133,5 @@
   =+  !<(=update:linedb q.save-done)
   ?.  ?=(%new-data -.update)             !!
   ?.  =((snip path-prefix) path.update)  !!
-  return-success
+  (return-success !>(p.build-result))
 --


### PR DESCRIPTION
**Problem**:

We build all registered files on commit, but should only build those that change.

**Solution**:

Use commit-level %diff on %linedb from https://github.com/uqbar-dao/linedb/pull/48

**Notes**:

None