### PR TITLE
ziggurat: re-add publish

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -606,7 +606,7 @@
       :-  ~
       state(projects (~(put by projects) project-name.act project))
     ::
-        %deploy-contract
+        %deploy-contract-virtualnet
       =/  =project:zig  (~(got by projects) project-name.act)
       =/  =desk:zig  (got-desk:zig-lib project desk-name.act)
       =/  queue-thread-error
@@ -643,7 +643,33 @@
         :^  %queue-thread  thread-name  %lard
         %-  send-wallet-transaction:zig-threads
         :^  who  u.host  !>(deploy-contract:zig-threads)
-        [who contract-jam-path.act %.n ~]
+        [[%& who] town-id.act contract-jam-path.act %.n ~]
+      (pure:m !>(~))
+    ::
+        %deploy-contract-livenet
+      =/  =project:zig  (~(got by projects) project-name.act)
+      =/  =desk:zig  (got-desk:zig-lib project desk-name.act)
+      =/  queue-thread-error
+        %~  queue-thread  make-error-vase:zig-lib
+        [update-info %error]
+      =*  thread-name=@tas
+        %^  cat  3  'deploy-contract-'
+        (spat contract-jam-path.act)
+      :_  state
+      :_  ~
+      %-  %~  arvo  pass:io  /deploy-contract
+      :^  %k  %lard  q.byk.bowl
+      %+  skip-queue:zig-threads  request-id.act
+      =/  m  (strand ,vase)
+      ^-  form:m
+      ;<  ~  bind:m
+        %+  poke-our:strandio  %ziggurat
+        :-  %ziggurat-action
+        !>  ^-  action:zig
+        :^  project-name.act  desk-name.act  request-id.act
+        :^  %queue-thread  thread-name  %lard
+        %+  deploy-contract:zig-threads  [%| from.act]
+        [town-id.act contract-jam-path.act %.n ~]
       (pure:m !>(~))
     ::
         %build-file

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1003,7 +1003,75 @@
       ==
     ::
         %publish-app
-      !!  :: TODO
+      =/  =project:zig  (~(got by projects) project-name.act)
+      =/  =desk:zig  (got-desk:zig-lib project desk-name.act)
+      =*  repo-host    (scot %p repo-host.repo-info.desk)
+      =*  repo-name    desk-name.act
+      =*  branch-name  branch-name.repo-info.desk
+      =*  commit-hash  commit-hash.repo-info.desk
+      =*  commit=@ta
+        ?~  commit-hash  %head
+        (scot %ux u.commit-hash)
+      =*  scry-prefix
+        :^  (scot %p our.bowl)  %linedb  (scot %da now.bowl)
+        /[repo-host]/[repo-name]/[branch-name]/[commit]
+      =|  cards=(list card)
+      ::  make desk.bill if it does not exist
+      =/  desk-bill-current-contents=(unit @t)
+        .^((unit @t) %gx (weld scry-prefix /desk/bill/noun))
+      =?  cards  ?=(~ desk-bill-current-contents)
+        :_  cards
+        %-  %~  arvo  pass:io
+            [%save project-name.act desk-name.act /desk/bill]
+        :^  %k  %lard  q.byk.bowl
+        (save-file:zig-threads /desk/bill '~')
+      ::  make desk.ship if it does not exist
+      =/  desk-ship-current-contents=(unit @t)
+        .^((unit @t) %gx (weld scry-prefix /desk/ship/noun))
+      =?  cards  ?=(~ desk-ship-current-contents)
+        :_  cards
+        %-  %~  arvo  pass:io
+            [%save project-name.act desk-name.act /desk/ship]
+        :^  %k  %lard  q.byk.bowl
+        %+  save-file:zig-threads  /desk/ship
+        (crip "{<our.bowl>}")
+      ::  make docket if it does not exist
+      =/  desk-docket-current-contents=(unit @t)
+        .^((unit @t) %gx (weld scry-prefix /desk/docket-0/noun))
+      =?  cards  ?=(~ desk-ship-current-contents)
+        :_  cards
+        %-  %~  arvo  pass:io
+            :^  %save  project-name.act  desk-name.act
+            /desk/docket-0
+        :^  %k  %lard  q.byk.bowl
+        %+  save-file:zig-threads  /desk/docket-0
+        %-  crip
+        """
+        :~  title+{<title.act>}
+            info+{<info.act>}
+            color+{<color.act>}
+            glob-ames+[{<our.bowl>} 0v0]
+            base+{<`@t`project-name.act>}
+            image+{<image.act>}
+            version+{<version.act>}
+            website+{<website.act>}
+            license+{<license.act>}
+        ==
+        """
+      ::  put files into our clay
+      =.  cards
+        :_  cards
+        %+  ~(poke-our pass:io /treaty-wire)  %linedb
+        :-  %linedb-action
+        !>
+        :^  %install  repo-host.repo-info.desk  repo-name
+        [branch-name commit-hash]
+      ::  publish via treaty
+      =.  cards
+        :_  cards
+        %+  ~(poke-our pass:io /treaty-wire)  %treaty
+        [%alliance-update-0 !>([%add our.bowl repo-name])]
+      [(flop cards) state]
     ::
         %add-user-file
       =/  =project:zig  (~(got by projects) project-name.act)

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -1577,6 +1577,12 @@
     ^-  vase
     !>  ^-  update:zig
     [%build-result update-info [%& ~] p]
+  ::
+  ++  deploy-contract
+    |=  [contract-id=@ux p=path]
+    ^-  vase
+    !>  ^-  update:zig
+    [%deploy-contract update-info [%& contract-id] p]
   --
 ::
 ++  make-error-vase
@@ -2213,7 +2219,8 @@
     ::
         [%register-for-compilation (ot ~[[%file pa]])]
         [%unregister-for-compilation (ot ~[[%file pa]])]
-        [%deploy-contract deploy]
+        [%deploy-contract-virtualnet deploy-virtual]
+        [%deploy-contract-livenet deploy-live]
     ::
         [%build-file (ot ~[[%path pa]])]
         [%watch-repo-for-changes ul]
@@ -2358,10 +2365,18 @@
         [%license so]
     ==
   ::
-  ++  deploy
+  ++  deploy-virtual
     ^-  $-(json [who=(unit @p) town-id=@ux contract-jam-path=path])
     %-  ot
     :~  [%who (se-soft %p)]
+        [%town-id (se %ux)]
+        [%contract-jam-path pa]
+    ==
+  ::
+  ++  deploy-live
+    ^-  $-(json [from=@ux town-id=@ux contract-jam-path=path])
+    %-  ot
+    :~  [%who (se %ux)]
         [%town-id (se %ux)]
         [%contract-jam-path pa]
     ==

--- a/lib/zig/ziggurat/threads.hoon
+++ b/lib/zig/ziggurat/threads.hoon
@@ -216,14 +216,14 @@
   (pure:m ~)
 ::
 ++  deploy-contract
-  |=  $:  who=@p
+  |=  $:  is-virtualnet-deployment=(each @p from=@ux)
+          town-id=@ux
           contract-jam-path=path
           mutable=?
           publish-contract-id=(unit @ux)  ::  ~ -> 0x1111.1111
       ==
   =/  m  (strand ,vase)
   ^-  form:m
-  =/  address=@ux  (~(got by ship-to-address) who)
   ;<  state=state-0:zig  bind:m  get-state
   =/  =project:zig
     (~(got by projects.state) project-name)
@@ -251,9 +251,7 @@
     (pure:m !>(`(unit @ux)`~))
   =/  code  [- +]:(cue u.code-atom)
   |^
-  ;<  empty-vase=vase  bind:m
-    %-  send-pyro-poke
-    :^  who  who  %uqbar
+  =*  wallet-poke-cage=cage
     :-  %wallet-poke 
     !>  ^-  wallet-poke:wallet
         :*  %transaction
@@ -263,11 +261,24 @@
             town=town-id
             [%noun %deploy mutable code interface=~]
         ==
-  (pure:m !>(`(unit @ux)``compute-contract-hash))
-  ::
-  ++  town-id
-    ^-  @ux
-    0x0  ::  hardcode
+  ;<  empty-vase=vase  bind:m
+    ?:  ?=(%& -.is-virtualnet-deployment)
+      =*  who  p.is-virtualnet-deployment
+      (send-pyro-poke who who %uqbar wallet-poke-cage)
+    ;<  ~  bind:m  (poke-our %wallet wallet-poke-cage)
+    (pure:m !>(~))
+  =/  contract-hash=@ux  compute-contract-hash
+  ;<  ~  bind:m
+    %+  poke-our  %ziggurat
+    :-  %ziggurat-action
+    !>  ^-  action:zig
+    :^  project-name  desk-name  ~
+    :-  %send-update
+    !<  update:zig
+    %.  [contract-hash contract-jam-path]
+    %~  deploy-contract  make-update-vase:zig-lib
+    [project-name desk-name %deploy-contract ~]
+  (pure:m !>(`(unit @ux)``contract-hash))
   ::
   ++  pci
     ^-  @ux
@@ -277,6 +288,12 @@
     ^-  @ux
     %-  hash-pact:smart
     [?.(mutable 0x0 pci) address town-id code]
+  ::
+  ++  address
+    ^-  @ux
+    ?:  ?=(%& -.is-virtualnet-deployment)
+      (~(got by ship-to-address) p.is-virtualnet-deployment)
+    from.p.is-virtualnet-deployment
   --
 ::
 ++  send-wallet-transaction

--- a/lib/zig/ziggurat/threads.hoon
+++ b/lib/zig/ziggurat/threads.hoon
@@ -251,6 +251,7 @@
     (pure:m !>(`(unit @ux)`~))
   =/  code  [- +]:(cue u.code-atom)
   |^
+  ::  TODO: send %update if contract-hash already exists
   =*  wallet-poke-cage=cage
     :-  %wallet-poke 
     !>  ^-  wallet-poke:wallet

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -146,7 +146,8 @@
       ::
           [%register-for-compilation file=path]
           [%unregister-for-compilation file=path]
-          [%deploy-contract who=(unit @p) town-id=@ux contract-jam-path=path]
+          [%deploy-contract-virtualnet who=(unit @p) town-id=@ux contract-jam-path=path]
+          [%deploy-contract-livenet from=@ux town-id=@ux contract-jam-path=path]
       ::
           [%build-file =path]
           [%watch-repo-for-changes ~]
@@ -217,6 +218,8 @@
       %build-result
       %long-operation-on-step
       %thread-result
+      %deploy-contract
+      %linedb
   ==
 +$  update-level  ?(%success error-level)
 +$  error-level   ?(%info %warning %error)
@@ -269,7 +272,7 @@
       [%build-result update-info payload=(data ~) =path]
       [%long-operation-current-step update-info payload=(data long-operation-info-body) ~]
       [%thread-result update-info payload=(data ~) thread-name=@tas]
-      [%deploy-contract update-info payload=(data ~) =path]
+      [%deploy-contract update-info payload=(data @ux) =path]
       [%linedb update-info payload=(data ~) ~]
   ==
 --


### PR DESCRIPTION
**Problem**:

We want to support publishing contracts and apps on the live network.

**Solution**:

1. Allow for deploying contracts on the livenet.
2. Re-add %publish-app code.

**Notes**:

I am imagining that we should provide a step-by-step GUI for the simplest possible few cases that users may want. More complex cases are "power user" territory. The cases I came up with to support are:
1. User wants to deploy 0 or 1 contract.
2. User wants to deploy 0 or 1 Gall app.

These are supported by two separate pokes:
1. `%deploy-contract-livenet`, which sends a transaction to the user's wallet to deploy the given contract (the user will then have to use the %wallet to sign and send the transaction to a %sequencer).
2. `%publish-app`, which will create some necessary files if they do not already exist (i.e. `desk.bill`, `desk.ship`, `desk.docket-0`) and then copy the files in the given repo from %linedb to clay and publish them.

Some things still to implement/figure out (for another PR, I think):
1. [%upgrade](https://github.com/uqbar-dao/uqbar-core/blob/master/con/lib/publish.hoon#L17-L20) rather than %deploy if a contract with the computed ID already exists (which will allow users to deploy contract upgrades from %ziggurat!).
2. How to get the computed contract ID from the contract step to the app step? I imagine it will be a common use case that a user has a pair of contract and Gall app and wants to hardcode the contract ID into the Gall app somewhere. For now, the user just needs to compute this themselves (perhaps we could provide a thread to make this trivially easy?). It would be really nice if we could automate this somehow, since we know the contract ID after that deployment step is done. For now we send it on the update subscription path.