### PR TITLE
ziggurat: reset state on failed %pyro load

### DIFF
--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -94,7 +94,7 @@
     =+  (mule |.(!<(versioned-state old-vase)))
     ?-  -.-
       %&  `this(state +.-)
-      %|  `this
+      %|  [[%give %fact ~[/load-failed] noun+!>(~)]~ this]
     ==
   ::
   ++  on-poke
@@ -144,7 +144,13 @@
       (scry:(pe who) (weld /gx/[her]/[dap]/0 paf))
     ==
   ::
-  ++  on-watch  on-watch:def
+  ++  on-watch
+    |=  p=path
+    ^-  (quip card _this)
+    ?+  p  (on-watch:def p)
+      [%load-failed ~]  `this
+    ==
+  ::
   ++  on-leave  on-leave:def
   ++  on-agent  on-agent:def
   ++  on-arvo   on-arvo:def

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1362,7 +1362,7 @@
             %-  send-long-operation-update:zig-threads
             ?~  long-operation-info  ~
             %=  long-operation-info
-                current-step.u  `%uild-configuration-thread
+                current-step.u  `%build-configuration-thread
             ==
           ;<  configuration-thread-vase=vase  bind:m
             %-  build:zig-threads  :_  config-file-path
@@ -1473,8 +1473,12 @@
     ?>  ?=([%fact %noun ^] sign)
     =^  cards=(list card)  this  on-init
     :_  this
-    :_  cards
-    (~(leave-our pass:io w) %pyro)
+    :+  (~(leave-our pass:io w) %pyro)
+      %-  update-vase-to-card:zig-lib
+      %.  'resetting %ziggurat state to factory settings due to %pyro state wipe upon arvo change'
+      %~  state-reset  make-error-vase:zig-lib
+      [['' %$ %pyro-load-failed ~] %error]
+    cards
   ::
       [%linedb @ @ @ @ ~]
     ?:  ?=(%watch-ack -.sign)  `this

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -42,6 +42,7 @@
     zig-lib  ~(. ziggurat-lib bowl settings)
 ::
 ++  on-init
+  ^-  (quip card _this)
   =*  scry-prefix=path
     :^  (scot %p our.bowl)  q.byk.bowl  (scot %da now.bowl)
     /lib/zig/sys
@@ -67,9 +68,11 @@
   =*  wes-address
     0x5da4.4219.e382.ad70.db07.0a82.12d2.0559.cf8c.b44d
   ~&  %z^%on-init
-  :-  :_  ~
-      %.  (add now.bowl ~s5)
-      ~(wait pass:io /on-init-zig-setup)
+  :-  :+  %.  [%pyro /load-failed]
+          ~(watch-our pass:io /pyro-load-failed)
+        %.  (add now.bowl ~s5)
+        ~(wait pass:io /on-init-zig-setup)
+      ~
   %_    this
       state
     :_  [eng smart-lib]
@@ -95,6 +98,7 @@
 ::
 ++  on-load
   |=  =old=vase
+  ^-  (quip card _this)
   ::  on-load: pre-cue our compiled smart contract library
   =*  scry-prefix=path
     :^  (scot %p our.bowl)  q.byk.bowl  (scot %da now.bowl)
@@ -1464,6 +1468,14 @@
   |=  [w=wire =sign:agent:gall]
   ^-  (quip card _this)
   ?+    w  (on-agent:def w sign)
+      [%pyro-load-failed ~]
+    ?:  ?=(%watch-ack -.sign)  `this
+    ?>  ?=([%fact %noun ^] sign)
+    =^  cards=(list card)  this  on-init
+    :_  this
+    :_  cards
+    (~(leave-our pass:io w) %pyro)
+  ::
       [%linedb @ @ @ @ ~]
     ?:  ?=(%watch-ack -.sign)  `this
     ?>  ?=([%fact %linedb-update ^] sign)

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -1682,6 +1682,12 @@
     ^-  vase
     !>  ^-  update:zig
     [%linedb update-info [%| level message] ~]
+  ::
+  ++  state-reset
+    |=  message=@t
+    ^-  vase
+    !>  ^-  update:zig
+    [%state-reset update-info [%| level message] ~]
   --
 ::
 ::  json
@@ -1863,6 +1869,9 @@
       ['data' ~]~
     ::
         %linedb
+      ['data' ~]~
+    ::
+        %state-reset
       ['data' ~]~
     ==
   ::

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -220,6 +220,7 @@
       %thread-result
       %deploy-contract
       %linedb
+      %state-reset
   ==
 +$  update-level  ?(%success error-level)
 +$  error-level   ?(%info %warning %error)
@@ -274,5 +275,6 @@
       [%thread-result update-info payload=(data ~) thread-name=@tas]
       [%deploy-contract update-info payload=(data @ux) =path]
       [%linedb update-info payload=(data ~) ~]
+      [%state-reset update-info payload=(data ~) ~]
   ==
 --


### PR DESCRIPTION
**Problem**:

When arvo is upgraded, %pyro does not upgrade %pyro ships. Currently, it resets state to a clean slate. %ziggurat is not informed and has state that still points to no-longer-existing %pyro state.

**Solution**:

Reset to initial %ziggurat state.

**Notes**:

~~WIP~~