### PR TITLE
ziggurat: dont auto-sync %suite desk

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -65,11 +65,23 @@
   =*  wes-address
     0x5da4.4219.e382.ad70.db07.0a82.12d2.0559.cf8c.b44d
   ~&  %z^%on-init
-  :-  :+  %.  [%pyro /load-failed]
-          ~(watch-our pass:io /pyro-load-failed)
-        %.  (add now.bowl ~s5)
-        ~(wait pass:io /on-init-zig-setup)
-      ~
+  :-  :^    %.  [%pyro /load-failed]
+            ~(watch-our pass:io /pyro-load-failed)
+          %.  (add now.bowl ~s5)
+          ~(wait pass:io /on-init-zig-setup)
+        %+  ~(poke-our pass:io /unsync-suite)  %hood
+        :-  %kiln-unsync
+        !>  ^-  [@tas @p @tas]
+        :+  q.byk.bowl
+          make-canonical-distribution-ship:zig-lib
+        q.byk.bowl
+      :_  ~
+      %-  %~  arvo  pass:io
+          /suite-desk-update
+      :^  %k  %lard  q.byk.bowl
+      %+  ~(watch-for-desk-update ziggurat-threads '' %$ ~)
+        make-canonical-distribution-ship:zig-lib
+      q.byk.bowl
   %_    this
       state
     :_  [eng smart-lib]
@@ -1256,6 +1268,14 @@
         %^  put-desk:zig-lib  project  desk-name.act
         desk(repo-info repo-info.act)
       ==
+    ::
+        %update-suite
+      :_  state
+      :_  ~
+      %-  ~(arvo pass:io /update-suite)
+      :^  %c  %merg  q.byk.bowl
+      :-  make-canonical-distribution-ship:zig-lib
+      [q.byk.bowl da+now.bowl %only-that]
     ==
     ::
     ++  compile-imports
@@ -1513,6 +1533,7 @@
       [%add-sync-desk-vships ~]       `this
       [%deploy-contract ~]            `this
       [%setup-project-desk @ ~]       `this
+      [%update-suite ~]               `this
       [%save @ @ ^]                   ::`this
     ~&  sign-arvo  `this
   ::
@@ -1532,6 +1553,27 @@
         make-canonical-distribution-ship:zig-lib
       %master
     :-  ~  !>(~)
+  ::
+      [%suite-desk-update ~]
+    ?.  ?&  ?=(%khan -.sign-arvo)
+            ?=(%arow -.+.sign-arvo)
+        ==
+      (on-arvo:def w sign-arvo)
+    =/  cards=(list card)
+      :_  ~
+      %-  %~  arvo  pass:io
+          /suite-desk-update
+      :^  %k  %lard  q.byk.bowl
+      %+  ~(watch-for-desk-update ziggurat-threads '' %$ ~)
+        make-canonical-distribution-ship:zig-lib
+      q.byk.bowl
+    ?:  ?=(%| -.p.+.sign-arvo)   [cards this]
+    ?.  !<(? q.p.p.+.sign-arvo)  [cards this]
+    :_  this
+    :_  cards
+    %-  update-vase-to-card:zig-lib
+    %~  suite-update-available  make-update-vase:zig-lib
+    ['' %$ %$ ~]
   ::
       [%build-result @ @ ^]
     =*  project-name  i.t.w

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -1583,6 +1583,11 @@
     ^-  vase
     !>  ^-  update:zig
     [%deploy-contract update-info [%& contract-id] p]
+  ::
+  ++  suite-update-available
+    ^-  vase
+    !>  ^-  update:zig
+    [%suite-update-available update-info [%& ~] ~]
   --
 ::
 ++  make-error-vase
@@ -1872,6 +1877,9 @@
       ['data' ~]~
     ::
         %state-reset
+      ['data' ~]~
+    ::
+        %suite-update-available
       ['data' ~]~
     ==
   ::
@@ -2296,6 +2304,8 @@
         [%get-dev-desk (se %p)]
     ::
         [%set-repo-info repo-info]
+    ::
+        [%update-suite ul]
     ==
   ::
   ++  repo-info

--- a/lib/zig/ziggurat/threads.hoon
+++ b/lib/zig/ziggurat/threads.hoon
@@ -767,6 +767,33 @@
   ~&  %z^%sf^%2
   (pure:m !>(~))
 ::
+::  +watch-for-desk-update
+::   inspired by kiln-sync, see e.g.,
+::   https://github.com/urbit/urbit/blob/develop/pkg/arvo/lib/hood/kiln.hoon#L1125-L1134
+::   https://github.com/urbit/urbit/blob/develop/pkg/arvo/lib/hood/kiln.hoon#L1176
+::   https://github.com/urbit/urbit/blob/develop/pkg/arvo/lib/hood/kiln.hoon#L1194
+::
+++  watch-for-desk-update
+  |=  [who=@p desk-name=@tas]
+  =/  m  (strand ,vase)
+  ^-  form:m
+  ;<  now=@da  bind:m  get-time
+  ;<  =riot:clay  bind:m
+    (warp who desk-name ~ %sing %w da+now /)
+  ?~  riot  (pure:m !>(%.n))
+  ?.  ?=(%cass p.r.u.riot)  (pure:m !>(%.n))
+  =/  [current-revision-number=@ @]  !<([@ud @] q.r.u.riot)
+  =/  next-revision-number=@ud  +(current-revision-number)
+  ;<  =riot:clay  bind:m
+    %^  warp  who  desk-name
+    [~ %sing %w ud+next-revision-number /]
+  ?~  riot  (pure:m !>(%.n))
+  ;<  =riot:clay  bind:m
+    %^  warp  who  desk-name
+    [~ %sing %v ud+next-revision-number /]
+  ?~  riot  (pure:m !>(%.n))
+  (pure:m !>(%.y))
+::
 ++  update-pyro-desks-to-repo
   =/  m  (strand ,vase)
   ^-  form:m

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -179,6 +179,8 @@
           [%get-dev-desk who=@p]
       ::
           [%set-repo-info =repo-info]
+      ::
+          [%update-suite ~]
       ==
   ==
 ::
@@ -221,6 +223,7 @@
       %deploy-contract
       %linedb
       %state-reset
+      %suite-update-available
   ==
 +$  update-level  ?(%success error-level)
 +$  error-level   ?(%info %warning %error)
@@ -276,5 +279,6 @@
       [%deploy-contract update-info payload=(data @ux) =path]
       [%linedb update-info payload=(data ~) ~]
       [%state-reset update-info payload=(data ~) ~]
+      [%suite-update-available update-info payload=(data ~) ~]
   ==
 --


### PR DESCRIPTION
**Problem**:

Arvo changes kill %pyro ships, causing a %pyro and %ziggurat state wipe. We do not want to wipe users' data without asking for their consent.

**Solution**:

Unsync %suite desk and add tools to inform user when updates come in and allow user to manually update.

**Notes**:

A `%suite-update-available` is sent out from our %ziggurat whenever the distributor's %suite desk changes. The FE should display this somehow and inform users of consequences of updating. The FE should also provide a button that send the `%update-suite` poke.

A draft of what we show users about the consequences of updating:

A new version of %suite is available. Updating %suite will wipe your %ziggurat data if arvo has been updated. If you have data you cannot afford to lose, DO NOT UPDATE.

@0x70b1a5 