### PR TITLE
ziggurat: improve %save-file

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -544,23 +544,26 @@
       %-  %~  arvo  pass:io
           [%save [project-name desk-name file]:act]
       :^  %k  %lard  q.byk.bowl
-      (save-file:zig-threads [file contents repo-info]:act)
+      %-  modify-file:zig-threads
+      [file `contents repo-info]:act
     ::
         %delete-file
-      !!  ::  TODO
-      :: ::  should show warning
-      :: =/  =project:zig  (~(got by projects) project-name.act)
-      :: =/  =desk:zig  (got-desk:zig-lib project desk-name.act)
-      :: =.  project
-      ::   %^  put-desk:zig-lib  project  desk-name.act
-      ::   %=  desk
-      ::       user-files  (~(del in user-files.desk) file.act)
-      ::       to-compile  (~(del in to-compile.desk) file.act)
-      ::   ==
-      :: :_  state(projects (~(put by projects) project-name.act project))
-      :: :_  ~
-      :: %-  ~(arvo pass:io /del-wire)
-      :: [%c %info desk-name.act %& [file.act %del ~]~]
+      ::  should show warning
+      ?>  =(focused-project project-name.act)  ::  TODO
+      =/  =project:zig  (~(got by projects) project-name.act)
+      =/  =desk:zig  (got-desk:zig-lib project desk-name.act)
+      =.  project
+        %^  put-desk:zig-lib  project  desk-name.act
+        %=  desk
+            user-files  (~(del in user-files.desk) file.act)
+            to-compile  (~(del in to-compile.desk) file.act)
+        ==
+      :_  state(projects (~(put by projects) project-name.act project))
+      :_  ~
+      %-  %~  arvo  pass:io
+          [%delete [project-name desk-name file]:act]
+      :^  %k  %lard  q.byk.bowl
+      (modify-file:zig-threads [file ~ repo-info]:act)
     ::
         %make-configuration-file
       =/  =project:zig  (~(got by projects) project-name.act)
@@ -879,7 +882,7 @@
       %-  %~  arvo  pass:io
           /save-thread/[project-name.act]/[thread-name.act]
       :^  %k  %lard  q.byk.bowl
-      (save-file:zig-threads thread-path thread-text ~)
+      (modify-file:zig-threads thread-path `thread-text ~)
     ::
         %delete-thread
       =/  =project:zig  (~(got by projects) project-name.act)
@@ -890,7 +893,7 @@
       =^  cards=(list card)  state
         %-  handle-poke
         :^  project-name.act  desk-name.act  request-id.act
-        [%delete-file thread-path]
+        [%delete-file thread-path ~]
       :-  cards
       %=  state
           projects
@@ -1049,7 +1052,7 @@
         %-  %~  arvo  pass:io
             [%save project-name.act desk-name.act /desk/bill]
         :^  %k  %lard  q.byk.bowl
-        (save-file:zig-threads /desk/bill '~' ~)
+        (modify-file:zig-threads /desk/bill `'~' ~)
       ::  make desk.ship if it does not exist
       =/  desk-ship-current-contents=(unit @t)
         .^((unit @t) %gx (weld scry-prefix /desk/ship/noun))
@@ -1058,8 +1061,8 @@
         %-  %~  arvo  pass:io
             [%save project-name.act desk-name.act /desk/ship]
         :^  %k  %lard  q.byk.bowl
-        %^  save-file:zig-threads  /desk/ship
-        (crip "{<our.bowl>}")  ~
+        %^  modify-file:zig-threads  /desk/ship
+        `(crip "{<our.bowl>}")  ~
       ::  make docket if it does not exist
       =/  desk-docket-current-contents=(unit @t)
         .^((unit @t) %gx (weld scry-prefix /desk/docket-0/noun))
@@ -1069,7 +1072,8 @@
             :^  %save  project-name.act  desk-name.act
             /desk/docket-0
         :^  %k  %lard  q.byk.bowl
-        %^  save-file:zig-threads  /desk/docket-0
+        %^  modify-file:zig-threads  /desk/docket-0
+        :-  ~
         %-  crip
         """
         :~  title+{<title.act>}
@@ -1552,6 +1556,8 @@
       [%setup-project-desk @ ~]       `this
       [%update-suite ~]               `this
       [%save @ @ ^]                   ::`this
+    ~&  sign-arvo  `this
+      [%delete @ @ ^]                 ::`this
     ~&  sign-arvo  `this
   ::
       [%on-init-zig-setup ~]

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1280,9 +1280,13 @@
         %set-repo-info
       =/  =project:zig  (~(got by projects) project-name.act)
       =/  =desk:zig  (got-desk:zig-lib project desk-name.act)
-      :-  :_  ~
-          %-  make-read-repo:zig-lib
-          [project-name desk-name request-id]:act
+      :-  :+  %-  make-read-repo:zig-lib
+              [project-name desk-name request-id]:act
+            %-  update-vase-to-card:zig-lib
+            %.  repo-info.act
+            %~  repo-info  make-update-vase:zig-lib
+            update-info
+          ~
       %=  state
           projects
         %+  ~(put by projects)  project-name.act

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -342,6 +342,26 @@
       %-  fact:io  :_  ~[/project]
       [%ziggurat-update !>(`update:zig`update.act)]
     ::
+        %watch-for-file-changes
+      =*  path-suffix=path
+        :-  (scot %p repo-host.act)
+        /[repo-name.act]/[branch-name.act]
+      :_  state
+      :_  ~
+      %.  [%linedb [%branch-updates path-suffix]]
+      %~  watch-our  pass:io
+      [%linedb project-name.act path-suffix]
+    ::
+        %cancel-watch-for-file-changes
+      =*  path-suffix=path
+        :-  (scot %p repo-host.act)
+        /[repo-name.act]/[branch-name.act]
+      :_  state
+      :_  ~
+      %.  %linedb
+      %~  leave-our  pass:io
+      [%linedb project-name.act path-suffix]
+    ::
         %change-focus
       |^
       =/  old=@t  focused-project
@@ -367,7 +387,9 @@
               new-project(saved-thread-queue ~)
             ==
         %+  weld  cards
-        %+  update-linedb-watches  ~
+        %+  update-linedb-watches:zig-lib
+          [focused-project ~]
+        :-  project-name.act
         (project-to-repo-infos:zig-lib new-project)
       =/  old-project=project:zig  (~(got by projects) old)
       =/  old-snap-path=path
@@ -383,27 +405,16 @@
             ~
           ==
       :_  %+  weld  cards
-          %+  update-linedb-watches
+          %+  update-linedb-watches:zig-lib
+            :-  focused-project
             (project-to-repo-infos:zig-lib old-project)
+          :-  project-name.act
           (project-to-repo-infos:zig-lib new-project)
       %+  ~(poke-our pass:io /pyro-wire)  %pyro
       :-  %pyro-action
       !>  ^-  action:pyro
       :+  %snap-ships  old-snap-path
       pyro-ships.old-project
-    ::
-    ++  update-linedb-watches
-      |=  [old=(list repo-info:zig) new=(list repo-info:zig)]
-      ^-  (list card)
-      %+  weld
-        %+  turn  old
-        |=  [repo-host=@p repo-name=@tas branch-name=@tas *]
-        %-  make-cancel-watch-for-file-changes:zig-lib
-        [focused-project repo-host repo-name branch-name]
-      %+  turn  new
-      |=  [repo-host=@p repo-name=@tas branch-name=@tas *]
-      %-  make-watch-for-file-changes:zig-lib
-      [project-name.act repo-host repo-name branch-name]
     ::
     ++  sync-out-of-date-desks
       |=  desks=(list desk:zig)
@@ -518,6 +529,8 @@
       ==
     ::
         %save-file
+      ~&  %z^%save-file^project-name.act
+      ?>  =(focused-project project-name.act)  ::  TODO
       =/  =project:zig  (~(got by projects) project-name.act)
       =/  =desk:zig  (got-desk:zig-lib project desk-name.act)
       =.  project
@@ -531,22 +544,23 @@
       %-  %~  arvo  pass:io
           [%save [project-name desk-name file]:act]
       :^  %k  %lard  q.byk.bowl
-      (save-file:zig-threads [file contents]:act)
+      (save-file:zig-threads [file contents repo-info]:act)
     ::
         %delete-file
-      ::  should show warning
-      =/  =project:zig  (~(got by projects) project-name.act)
-      =/  =desk:zig  (got-desk:zig-lib project desk-name.act)
-      =.  project
-        %^  put-desk:zig-lib  project  desk-name.act
-        %=  desk
-            user-files  (~(del in user-files.desk) file.act)
-            to-compile  (~(del in to-compile.desk) file.act)
-        ==
-      :_  state(projects (~(put by projects) project-name.act project))
-      :_  ~
-      %-  ~(arvo pass:io /del-wire)
-      [%c %info desk-name.act %& [file.act %del ~]~]
+      !!  ::  TODO
+      :: ::  should show warning
+      :: =/  =project:zig  (~(got by projects) project-name.act)
+      :: =/  =desk:zig  (got-desk:zig-lib project desk-name.act)
+      :: =.  project
+      ::   %^  put-desk:zig-lib  project  desk-name.act
+      ::   %=  desk
+      ::       user-files  (~(del in user-files.desk) file.act)
+      ::       to-compile  (~(del in to-compile.desk) file.act)
+      ::   ==
+      :: :_  state(projects (~(put by projects) project-name.act project))
+      :: :_  ~
+      :: %-  ~(arvo pass:io /del-wire)
+      :: [%c %info desk-name.act %& [file.act %del ~]~]
     ::
         %make-configuration-file
       =/  =project:zig  (~(got by projects) project-name.act)
@@ -562,8 +576,8 @@
       =^  cards=(list card)  state
         %-  handle-poke
         :^  project-name.act  desk-name.act  request-id.act
-        :+  %save-file  configuration-file-path
-        configuration-file-text
+        :^  %save-file  configuration-file-path
+        configuration-file-text  ~
       [cards state]
     ::
         %add-config
@@ -865,7 +879,7 @@
       %-  %~  arvo  pass:io
           /save-thread/[project-name.act]/[thread-name.act]
       :^  %k  %lard  q.byk.bowl
-      (save-file:zig-threads thread-path thread-text)
+      (save-file:zig-threads thread-path thread-text ~)
     ::
         %delete-thread
       =/  =project:zig  (~(got by projects) project-name.act)
@@ -1035,7 +1049,7 @@
         %-  %~  arvo  pass:io
             [%save project-name.act desk-name.act /desk/bill]
         :^  %k  %lard  q.byk.bowl
-        (save-file:zig-threads /desk/bill '~')
+        (save-file:zig-threads /desk/bill '~' ~)
       ::  make desk.ship if it does not exist
       =/  desk-ship-current-contents=(unit @t)
         .^((unit @t) %gx (weld scry-prefix /desk/ship/noun))
@@ -1044,8 +1058,8 @@
         %-  %~  arvo  pass:io
             [%save project-name.act desk-name.act /desk/ship]
         :^  %k  %lard  q.byk.bowl
-        %+  save-file:zig-threads  /desk/ship
-        (crip "{<our.bowl>}")
+        %^  save-file:zig-threads  /desk/ship
+        (crip "{<our.bowl>}")  ~
       ::  make docket if it does not exist
       =/  desk-docket-current-contents=(unit @t)
         .^((unit @t) %gx (weld scry-prefix /desk/docket-0/noun))
@@ -1055,7 +1069,7 @@
             :^  %save  project-name.act  desk-name.act
             /desk/docket-0
         :^  %k  %lard  q.byk.bowl
-        %+  save-file:zig-threads  /desk/docket-0
+        %^  save-file:zig-threads  /desk/docket-0
         %-  crip
         """
         :~  title+{<title.act>}
@@ -1069,6 +1083,7 @@
             license+{<license.act>}
         ==
         """
+        ~
       ::  put files into our clay
       =.  cards
         :_  cards

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -2313,7 +2313,7 @@
         [%delete-project-desk ul]
     ::
         [%save-file (ot ~[[%file pa] [%contents so] [%repo-info repo-info-soft]])]  :: TODO: allow non-@t %contents
-        [%delete-file (ot ~[[%file pa]])]
+        [%delete-file (ot ~[[%file pa] [%repo-info repo-info-soft]])]
         [%make-configuration-file ul]
     ::
         [%add-config (ot ~[[%who (se %p)] [%what (se %tas)] [%item ni]])]

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -1640,6 +1640,12 @@
     ^-  vase
     !>  ^-  update:zig
     [%suite-update-available update-info [%& ~] ~]
+  ::
+  ++  repo-info
+    |=  =repo-info:zig
+    ^-  vase
+    !>  ^-  update:zig
+    [%repo-info update-info [%& repo-info] ~]
   --
 ::
 ++  make-error-vase
@@ -1933,6 +1939,9 @@
     ::
         %suite-update-available
       ['data' ~]~
+    ::
+        %repo-info
+      ['data' (repo-info p.payload.update)]~
     ==
   ::
   ++  long-operation-info-body

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -206,10 +206,21 @@
           branch-name=@tas
       ==
   ^-  card
-  =*  path-suffix=path
-    /(scot %p repo-host)/[repo-name]/[branch-name]
-  %+  ~(watch-our pass:io [%linedb project-name path-suffix])
-  %linedb  [%branch-updates path-suffix]
+  %-  ~(poke-self pass:io /make-watch-for-file-changes)
+  %-  make-watch-for-file-changes-cage
+  [project-name repo-host repo-name branch-name]
+::
+++  make-watch-for-file-changes-cage
+  |=  $:  project-name=@tas
+          repo-host=@p
+          repo-name=@tas
+          branch-name=@tas
+      ==
+  ^-  cage
+  :-  %ziggurat-action
+  !>  ^-  action:zig
+  :^  project-name  %$  ~
+  [%watch-for-file-changes repo-host repo-name branch-name]
 ::
 ++  make-cancel-watch-for-file-changes
   |=  $:  project-name=@tas
@@ -218,11 +229,22 @@
           branch-name=@tas
       ==
   ^-  card
-  =*  path-suffix=path
-    /(scot %p repo-host)/[repo-name]/[branch-name]
-  ^-  card
-  %.  %linedb
-  ~(leave-our pass:io [%linedb project-name path-suffix])
+  %-  ~(poke-self pass:io /make-cancel-watch-for-file-changes)
+  %-  make-cancel-watch-for-file-changes-cage
+  [project-name repo-host repo-name branch-name]
+::
+++  make-cancel-watch-for-file-changes-cage
+  |=  $:  project-name=@tas
+          repo-host=@p
+          repo-name=@tas
+          branch-name=@tas
+      ==
+  ^-  cage
+  :-  %ziggurat-action
+  !>  ^-  action:zig
+  :^  project-name  %$  ~
+  :-  %cancel-watch-for-file-changes
+  [repo-host repo-name branch-name]
 ::
 ++  get-most-recent-commit
   |=  [repo-host=@p repo-name=@tas branch-name=@tas]
@@ -1406,6 +1428,36 @@
     `desk-name
   $(desk-names t.desk-names)
 ::
+++  update-linedb-watches
+  |=  $:  old=(pair @tas (list repo-info:zig))
+          new=(pair @tas (list repo-info:zig))
+      ==
+  ^-  (list card)
+  %+  weld
+    %+  turn  q.old
+    |=  [repo-host=@p repo-name=@tas branch-name=@tas *]
+    %-  make-cancel-watch-for-file-changes
+    [p.old repo-host repo-name branch-name]
+  %+  turn  q.new
+  |=  [repo-host=@p repo-name=@tas branch-name=@tas *]
+  %-  make-watch-for-file-changes
+  [p.new repo-host repo-name branch-name]
+::
+++  update-linedb-watches-cages
+  |=  $:  old=(pair @tas (list repo-info:zig))
+          new=(pair @tas (list repo-info:zig))
+      ==
+  ^-  (list cage)
+  %+  weld
+    %+  turn  q.old
+    |=  [repo-host=@p repo-name=@tas branch-name=@tas *]
+    %-  make-cancel-watch-for-file-changes-cage
+    [p.old repo-host repo-name branch-name]
+  %+  turn  q.new
+  |=  [repo-host=@p repo-name=@tas branch-name=@tas *]
+  %-  make-watch-for-file-changes-cage
+  [p.new repo-host repo-name branch-name]
+::
 ++  update-vase-to-card
   |=  v=vase
   ^-  card
@@ -2260,7 +2312,7 @@
         [%add-project-desk (ot ~[[%index ni:dejs-soft:format] [%repo-host (se %p)] [%branch-name (se %tas)] [%commit-hash (se-soft %ux)]])]
         [%delete-project-desk ul]
     ::
-        [%save-file (ot ~[[%file pa] [%contents so]])]  :: TODO: allow non-@t %contents
+        [%save-file (ot ~[[%file pa] [%contents so] [%repo-info repo-info-soft]])]  :: TODO: allow non-@t %contents
         [%delete-file (ot ~[[%file pa]])]
         [%make-configuration-file ul]
     ::
@@ -2307,6 +2359,11 @@
     ::
         [%update-suite ul]
     ==
+  ::
+  ++  repo-info-soft
+    |=  jon=json
+    ^-  (unit repo-info:zig)
+    ?.(?=([%o *] jon) ~ (some (repo-info jon)))
   ::
   ++  repo-info
     ^-  $-(json repo-info:zig)

--- a/lib/zig/ziggurat/threads.hoon
+++ b/lib/zig/ziggurat/threads.hoon
@@ -769,9 +769,9 @@
   ~&  %z^%binh^%6
   (pure:m !>(repo-info))
 ::
-++  save-file
+++  modify-file
   |=  $:  file-path=path
-          file-contents=@
+          file-contents=(unit @)  ::  ~ -> delet
           maybe-repo-info=(unit repo-info:zig)
       ==
   =/  m  (strand ,vase)
@@ -832,9 +832,10 @@
     :-  %linedb-action
     !>  ^-  action:linedb
     :^  %commit  repo-name  branch-name
+    ?~  file-contents  (~(del by snap) file-path)
     %+  ~(put by snap)  file-path
-    ?.  ((sane %t) file-contents)  ~[file-contents]
-    (to-wain:format file-contents)
+    ?.  ((sane %t) u.file-contents)  ~[u.file-contents]
+    (to-wain:format u.file-contents)
   ~&  %z^%sf^%4
   (pure:m !>(~))
 ::

--- a/lib/zig/ziggurat/threads.hoon
+++ b/lib/zig/ziggurat/threads.hoon
@@ -782,7 +782,8 @@
   =/  old-project=project:zig
     (~(got by projects.state) project-name)
   =/  =desk:zig  (got-desk:zig-lib old-project desk-name)
-  ~&  %z^%sf^%1^repo-info.desk
+  =/  old-repo-info=repo-info:zig  repo-info.desk
+  ~&  %z^%sf^%1^old-repo-info
   ;<  repo-info-vase=vase  bind:m
     %-  branch-if-remote
     ?~(maybe-repo-info repo-info.desk u.maybe-repo-info)
@@ -837,6 +838,20 @@
     ?.  ((sane %t) u.file-contents)  ~[u.file-contents]
     (to-wain:format u.file-contents)
   ~&  %z^%sf^%4
+  ;<  empty-vase=vase  bind:m
+    ?:  =(old-repo-info repo-info)  (pure:m !>(~))
+    ;<  ~  bind:m
+      %+  poke-our  %ziggurat
+      :-  %ziggurat-action
+      !>  ^-  action:zig
+      :^  project-name  desk-name  ~
+      :-  %send-update
+      !<  update:zig
+      %.  repo-info
+      %~  repo-info  make-update-vase:zig-lib
+      [project-name desk-name %modify-file ~]
+    (pure:m !>(~))
+  ~&  %z^%sf^%5
   (pure:m !>(~))
 ::
 ::  +watch-for-desk-update

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -132,12 +132,14 @@
           [%send-state-views =state-views]
           [%set-ziggurat-state new-state=state-0]
           [%send-update =update]
+          [%watch-for-file-changes repo-host=@p repo-name=@tas branch-name=@tas]
+          [%cancel-watch-for-file-changes repo-host=@p repo-name=@tas branch-name=@tas]
       ::
           [%change-focus ~]
           [%add-project-desk index=(unit @ud) repo-host=@p branch-name=@tas commit-hash=(unit @ux)]  ::  index=~ -> add to end
           [%delete-project-desk ~]
       ::
-          [%save-file file=path contents=@]  ::  generates new file or overwrites existing
+          [%save-file file=path contents=@ repo-info=(unit repo-info)]  ::  generates new file or overwrites existing
           [%delete-file file=path]
           [%make-configuration-file ~]
       ::

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -226,6 +226,7 @@
       %linedb
       %state-reset
       %suite-update-available
+      %repo-info
   ==
 +$  update-level  ?(%success error-level)
 +$  error-level   ?(%info %warning %error)
@@ -282,5 +283,6 @@
       [%linedb update-info payload=(data ~) ~]
       [%state-reset update-info payload=(data ~) ~]
       [%suite-update-available update-info payload=(data ~) ~]
+      [%repo-info update-info payload=(data repo-info) ~]
   ==
 --

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -140,7 +140,7 @@
           [%delete-project-desk ~]
       ::
           [%save-file file=path contents=@ repo-info=(unit repo-info)]  ::  generates new file or overwrites existing
-          [%delete-file file=path]
+          [%delete-file file=path repo-info=(unit repo-info)]
           [%make-configuration-file ~]
       ::
           [%add-config who=@p what=@tas item=@]

--- a/ted/ziggurat/build.hoon
+++ b/ted/ziggurat/build.hoon
@@ -119,7 +119,8 @@
   =*  jam-path
     (need (convert-contract-hoon-to-jam:zig-lib file-path))
   ;<  empty-vase=vase  bind:m
-    (save-file:zig-threads jam-path (jam p.build-result))
+    %^  modify-file:zig-threads  jam-path
+    `(jam p.build-result)  ~
   ;<  ~  bind:m
     %^  watch-our  /save-done  %linedb
     [%branch-updates (snip path-prefix)]


### PR DESCRIPTION
**Problem**:

%save-file always adds to head.

**Solution**:

%save-file has optional `repo-info=(unit repo-info:zig)` field. If supplied, will branch off from that commit. If not supplied, will work from the `repo-info.desk`: if that has head commit, will append to head, else will branch off from the commit in that `repo-info.desk`.

Regardless, the `repo-info.desk` is updated to head of new branch.

**Notes**:

~~WIP~~

~~This should work, but I need to fix %delete-file (which I realized was still using clay).~~

As of f68a247, %delete-file works. It also has a new `repo-info=(unit repo-info:zig)` field.
Now thinking about whether %save-thread and such should also have a `repo-info` field.

Update: for now: no.