### PR TITLE
Da/remote scry

### DIFF
--- a/app/pyre.hoon
+++ b/app/pyre.hoon
@@ -33,13 +33,13 @@
   ::
       %pyro-effect
     =+  ef=!<([pyro-effect] vase)
-    ?-    -.q.ufs.ef
+    ?-    -.q.uf.ef
     ::  ames
-        %send  [(send:ames:hc now.bowl who.ef ufs.ef) this]
+        %send  [(send:ames:hc who.ef uf.ef) this]
     ::  behn
         %doze
       =^  cards  behn-piers
-        abet:(doze:(behn:hc who.ef) ufs.ef)
+        abet:(doze:(behn:hc who.ef) uf.ef)
       [cards this]
     ::  clay
         %ergo  `this
@@ -52,12 +52,12 @@
         %thus  `this
         %response
       =^  cards  eyre-piers
-        abet:(handle-response:(eyre who.ef) ufs.ef)
+        abet:(handle-response:(eyre who.ef) uf.ef)
       [cards this]
     ::  iris
         %request
       =^  cards  iris-piers
-        abet:(request:(iris:hc who.ef) ufs.ef)
+        abet:(request:(iris:hc who.ef) uf.ef)
       [cards this]
     ::  gall
         %poke-ack  `this
@@ -115,14 +115,23 @@
 ++  ames
   |%
   ++  send
-    |=  [now=@da sndr=@p way=wire %send lan=lane:^ames pac=@]
+    =,  ^ames
+    |=  [sndr=@p way=wire %send lan=lane pac=@]
     ^-  (list card:agent:gall)
     =/  rcvr=ship
       ?-  -.lan
         %&  p.lan
         %|  `ship``@`p.lan
       ==
-    =/  hear-lane  %|^`address:^ames``@`sndr
+    =/  hear-lane  %|^`address``@`sndr
+    =/  =shot  (sift-shot pac)
+    ~&  >>  shot
+    ?:  &(!sam.shot req.shot) :: TODO I beleive this is right
+      =/  =peep  +:(sift-wail `@ux`content.shot)
+      :: now remote-scry this from pyro
+      :: then inject it back as an event into sndr
+      ~&  >  peep
+      ~
     :_  ~
     :*  %pass  /pyro-events  %agent  [our.bowl %pyro]  %poke
         %pyro-events  !>([rcvr /a/newt/0v1n.2m9vh %hear hear-lane pac]~)

--- a/app/pyre.hoon
+++ b/app/pyre.hoon
@@ -144,6 +144,17 @@
               spr.bal                                                   ::  /kids/ted/keen/hoon
               /noun :: TODO swap out for noun or something else
         ==  ==
+    =.  pacs
+      ::  add request to each response packet payload
+      ::
+      =+  pat=(spat path.peep)
+      =+  wid=(met 3 pat)
+      %-  flop  =<  blobs
+      %+  roll  pacs
+      |=  [=yowl num=_1 blobs=(list @ux)]
+      :-  +(num)
+      :_  blobs
+      (can 3 4^num 2^wid wid^`@`pat (met 3 yowl)^yowl ~)
     :_  ~
     :*  %pass  /pyro-events  %agent  [our.bowl %pyro]  %poke
         %pyro-events

--- a/app/pyre.hoon
+++ b/app/pyre.hoon
@@ -123,18 +123,34 @@
         %&  p.lan
         %|  `ship``@`p.lan
       ==
-    =/  hear-lane  %|^`address``@`sndr
     =/  =shot  (sift-shot pac)
-    ~&  >>  shot
-    ?:  &(!sam.shot req.shot) :: TODO I beleive this is right
-      =/  =peep  +:(sift-wail `@ux`content.shot)
-      :: now remote-scry this from pyro
-      :: then inject it back as an event into sndr
-      ~&  >  peep
-      ~
-    :_  ~
+    ?.  &(!sam.shot req.shot) :: TODO I beleive this is right
+      ::  normal packet
+      ::
+      :_  ~
+      :*  %pass  /pyro-events  %agent  [our.bowl %pyro]  %poke
+          %pyro-events  !>([rcvr /a/newt/0v1n.2m9vh %hear %|^`address``@`sndr pac]~)
+      ==
+    ::  remote scry packet
+    ::
+    =/  =peep  +:(sift-wail `@ux`content.shot)
+    :: unpack path.peep
+    =+  bal=(de-path:balk path.peep)
+    =+  .^  pacs=(list yowl)  %gx
+            ;:  weld
+              /(scot %p our.bowl)/pyro/(scot %da now.bowl)/r            ::  /=pyro=/r
+              /(scot %p her.bal)/(scot %ud rif.bal)/(scot %ud lyf.bal)  ::  /~wes/0/1/
+              /[van.bal]/[car.bal]/(scot cas.bal)                       ::  /c/x/1
+              spr.bal                                                   ::  /kids/ted/keen/hoon
+              /noun :: TODO swap out for noun or something else
+        ==  ==
+    %+  turn  pacs
+    |=  =yowl
     :*  %pass  /pyro-events  %agent  [our.bowl %pyro]  %poke
-        %pyro-events  !>([rcvr /a/newt/0v1n.2m9vh %hear hear-lane pac]~)
+        %pyro-events
+        :: =+  shot=(sift-shot `@`yowl)
+        :: =/  asdf  (etch-shot shot(sndr sndr, rcvr rcvr))
+        !>([sndr /a/newt/0v1n.2m9vh %hear %|^`address``@`rcvr `blob``@`yowl]~)
     ==
   --
 ::

--- a/app/pyre.hoon
+++ b/app/pyre.hoon
@@ -144,14 +144,22 @@
               spr.bal                                                   ::  /kids/ted/keen/hoon
               /noun :: TODO swap out for noun or something else
         ==  ==
-    %+  turn  pacs
-    |=  =yowl
+    :_  ~
     :*  %pass  /pyro-events  %agent  [our.bowl %pyro]  %poke
         %pyro-events
-        :: =+  shot=(sift-shot `@`yowl)
-        :: =/  asdf  (etch-shot shot(sndr sndr, rcvr rcvr))
-        !>([sndr /a/newt/0v1n.2m9vh %hear %|^`address``@`rcvr `blob``@`yowl]~)
-    ==
+        !>
+        %+  turn  pacs
+        |=  =yowl
+        :+  sndr  /a/pyro/fine-response
+        :+  %hear  %|^`address``@`sndr
+        %-  etch-shot
+        :*  [sndr=rcvr rcvr=sndr]
+            req=|  sam=|
+            sndr-tick=`@ubC`1
+            rcvr-tick=`@ubC`1
+            origin=~
+            content=`@ux`yowl
+    ==  ==
   --
 ::
 ++  behn

--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -54,7 +54,7 @@
           scry-time=@da
           namespace=(map path (list yowl:ames))
       ==
-    +$  card  card:agent:gall
+    +$  card  $+(card card:agent:gall)
     --
 ::
 =|  state-0
@@ -109,7 +109,7 @@
     [cards this]
   ::
   ++  on-peek
-    |=  =path
+    |=  =path :: TODO (pole knot) faceless path
     ^-  (unit (unit cage))
     ?+    path  ~
         [%x %snaps ~]
@@ -134,6 +134,12 @@
       =/  who  (slav %p i.t.t.path)
       =*  paf  t.t.t.path
       (scry:(pe who) paf)
+    ::  remote-scry into running virtual ships
+    ::  NOTE: requires a double mark at the end
+    ::
+        [%x %r @ @ @ @ta @ta *]  :: TODO [%x %r @ ^]
+      =/  who  (slav %p i.t.t.path)
+      (remote-scry:(pe who) [%fine %hunk '1' '13' t.t.path]) :: TODO 1.000.000
     ::  convenience scry for a virtual ship's running gall app
     ::  ship, app, path
     ::
@@ -272,11 +278,12 @@
     ``[p.u.u.res !<(vase [-:!>(*vase) q.u.u.res])]
   ::
   ++  remote-scry
-    |=  [=view =desk =spur]
+    |=  =spur
+    ^-  (unit (unit cage))
     =/  res
       %-  ~(peek le:part:snap [[pit vil] sol]:snap)
-      [[~ ~] view [who desk da/scry-time.pier-data] spur]
-    ?~  res    res
+      [[~ ~] %ax [who %$ da+scry-time:pier-data] spur]
+    ?~    res  res
     ?~  u.res  res
     ``[p.u.u.res !<(vase [-:!>(*vase) q.u.u.res])]
   ::

--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -52,6 +52,7 @@
           next-events=(qeu unix-event)
           paused=?
           scry-time=@da
+          namespace=(map path (list yowl:ames))
       ==
     +$  card  card:agent:gall
     --
@@ -267,6 +268,15 @@
     ::  execute scry
     ?~  mon=(de-omen path)  ~
     ?~  res=(~(peek le:part:snap [[pit vil] sol]:snap) [`~ u.mon])  ~
+    ?~  u.res  res
+    ``[p.u.u.res !<(vase [-:!>(*vase) q.u.u.res])]
+  ::
+  ++  remote-scry
+    |=  [=view =desk =spur]
+    =/  res
+      %-  ~(peek le:part:snap [[pit vil] sol]:snap)
+      [[~ ~] view [who desk da/scry-time.pier-data] spur]
+    ?~  res    res
     ?~  u.res  res
     ``[p.u.u.res !<(vase [-:!>(*vase) q.u.u.res])]
   ::

--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -52,7 +52,6 @@
           next-events=(qeu unix-event)
           paused=?
           scry-time=@da
-          namespace=(map path (list yowl:ames))
       ==
     +$  card  $+(card card:agent:gall)
     --

--- a/gen/pyre/resub.hoon
+++ b/gen/pyre/resub.hoon
@@ -1,7 +1,0 @@
-:: Resub %pyre to %pyro subscriptions
-:: Usage: :pyre|resub
-::
-:-  %say
-|=  *
-:-  %noun
-[%resub ~]

--- a/sur/zig/pyro.hoon
+++ b/sur/zig/pyro.hoon
@@ -49,7 +49,7 @@
 +$  pyro-event    [who=ship ue=unix-event]
 +$  pyro-events   [who=ship utes=(list unix-timed-event)]
 +$  pyro-effects  [who=ship ufs=(list unix-effect)]
-+$  pyro-effect   [who=ship ufs=unix-effect]
++$  pyro-effect   [who=ship uf=unix-effect]
 +$  pyro-boths    [who=ship ub=(list unix-both)]
 ::
 +$  action


### PR DESCRIPTION
**Problem**:
Remote scry doesn't work on pyro ships

**Solution**:
Implement it in the runtime

**Notes**:
Random other fixes
- `$pyro-effect` `unix-effect` face changed to `uf` instead of `ufs`
- Superfluous `:pyre|resub` generator removed