### PR TITLE
ziggurat: building from project repo passes in other repos for deps

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -883,10 +883,7 @@
         :^  %k  %fard  q.byk.bowl
         :-  %ziggurat-build
         :-  %noun
-        !>  :-  ~
-            :^  project-name.act  desk-name.act
-              request-id.act
-            [repo-host branch-name commit-hash path.act]
+        !>(`[project-name desk-name request-id path]:act)
       ~
     ::
         %watch-repo-for-changes
@@ -981,7 +978,7 @@
       ^-  form:m
       ~&  %z^%qt^%0
       ;<  thread-vase=vase  bind:m
-        (build:zig-sys-threads ri u.thread-path)
+        (build:zig-sys-threads u.thread-path ~)
       ~&  %z^%qt^%1
       =+  !<(thread=(each vase tang) thread-vase)
       ?:  ?=(%| -.thread)
@@ -1571,7 +1568,7 @@
           :-  %|
           [%leaf "could not find import {<import-path>}"]~
         ;<  result-vase=vase  bind:m
-          (build:zig-sys-threads u.repo-info import-path)
+          (build:zig-sys-threads import-path ~)
         =+  !<(result=(each vase tang) result-vase)
         ?:  ?=(%| -.result)  (pure:m [%| p.result])
         %=  $
@@ -1640,8 +1637,8 @@
                 current-step.u  `%build-configuration-thread
             ==
           ;<  configuration-thread-vase=vase  bind:m
-            %-  build:zig-sys-threads  :_  config-file-path
-            [repo-host desk-name branch-name commit-hash]
+            %+  build:zig-sys-threads  config-file-path
+            [repo-host desk-name branch-name commit-hash]~
           =+  !<  configuration-thread=(each vase tang)
               configuration-thread-vase
           ?:  ?=(%| -.configuration-thread)

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1530,6 +1530,40 @@
             (snoc q %noun)
         ==
       `repo-info.desk
+    ::
+        %copy-shared-files
+      =*  scry-prefix=path
+        /(scot %p our.bowl)/linedb/(scot %da now.bowl)
+      =*  from-commit=@ta
+        ?~  commit-hash.from.act  %head
+        (scot %ux u.commit-hash.from.act)
+      =*  from-path=path
+        :+  (scot %p repo-host.from.act)  repo-name.from.act
+        /[branch-name.from.act]/[from-commit]/noun
+      =*  from
+        .^  (map path wain)
+            %gx
+            (weld scry-prefix from-path)
+        ==
+      =*  to-commit=@ta
+        ?~  commit-hash.to.act  %head
+        (scot %ux u.commit-hash.to.act)
+      =*  to-path=path
+        :+  (scot %p repo-host.to.act)  repo-name.to.act
+        /[branch-name.to.act]/[to-commit]/noun
+      =+  .^  to=(map path wain)
+              %gx
+              (weld scry-prefix to-path)
+          ==
+      =/  updated-to=(map path wain)  (~(int by to) from)
+      :_  state
+      ?:  =(to updated-to)  ~
+      :_  ~
+      %+  %~  poke-our  pass:io  /copy-shared-files
+        %linedb
+      :-  %linedb-action
+      !>  ^-  action:linedb
+      [%commit repo-name.to.act branch-name.to.act updated-to]
     ==
     ::
     ++  compile-imports
@@ -1787,6 +1821,7 @@
       [%setup-project-desk @ ~]        `this
       [%update-suite ~]                `this
       [%copy-files-to-project-repo ~]  `this
+      [%copy-shared-files ~]  `this
       [%fork-project @ @ ~]
     ~&  sign-arvo  `this
       [%save @ @ ^]                   ::`this

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -1,0 +1,1 @@
+../../linedb/lib/linedb.hoon

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -2433,6 +2433,8 @@
     ::
         [%find-files-amongst-repos (ot ~[[%files (as pa)] [%repos (ar pa)]])]
         [%copy-files-to-project-repo (ot ~[[%files-to-repo-path-files (op stap pa)]])]
+    ::
+        [%copy-shared-files (ot ~[[%from repo-info] [%to repo-info]])]
     ==
   ::
   ++  fork-project

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -206,6 +206,8 @@
       ::
           [%find-files-amongst-repos files=(set path) repos=(list path)]
           [%copy-files-to-project-repo files-to-repo-path-files=(map path path)]
+      ::
+          [%copy-shared-files from=repo-info to=repo-info]
       ==
   ==
 ::

--- a/ted/ziggurat/build.hoon
+++ b/ted/ziggurat/build.hoon
@@ -3,6 +3,7 @@
     zig=zig-ziggurat
 /+  strandio,
     zig-lib=zig-ziggurat,
+    ziggurat-threads=zig-ziggurat-threads,
     ziggurat-system-threads=zig-ziggurat-system-threads
 ::
 =*  strand         strand:spider
@@ -21,6 +22,8 @@
 =|  project-name=@t
 =|  desk-name=@tas
 =|  start=@da
+=*  zig-threads
+  ~(. ziggurat-threads project-name desk-name ~)
 =*  zig-sys-threads
   ~(. ziggurat-system-threads project-name desk-name)
 |^  ted
@@ -29,17 +32,8 @@
   $:  project-name=@t
       desk-name=@tas
       request-id=(unit @t)
-      repo-host=@p
-      branch-name=@tas
-      commit-hash=(unit @ux)
       file-path=path
   ==
-::
-++  return-success
-  |=  result=vase
-  =/  m  (strand ,vase)
-  ^-  form:m
-  (pure:m !>(`(each vase tang)`[%& result]))
 ::
 ++  return-error
   |=  message=tape
@@ -64,74 +58,7 @@
   =.  project-name  project-name.u.args
   =.  desk-name     desk-name.u.args
   =*  request-id    request-id.u.args
-  =*  repo-host     repo-host.u.args
-  =*  branch-name   branch-name.u.args
-  =*  commit-hash   commit-hash.u.args
   =*  file-path     file-path.u.args
   ?~  file-path  (return-error "file-path must be non-~")
-  ?.  =(%con i.file-path)
-    ;<  =bowl:strand  bind:m  get-bowl
-    ;<  ~  bind:m
-      %+  poke-our  %linedb
-      :-  %linedb-action
-      !>  ^-  action:linedb
-      :^  %build  repo-host  desk-name
-      [branch-name commit-hash file-path [%ted tid.bowl]]
-    ~&  %zb^%non-con^%0
-    ;<  build-result=vase  bind:m  (take-poke %linedb-update)
-    ~&  %zb^%non-con^%1
-    =+  !<(=update:linedb build-result)
-    ?.  ?=(%build -.update)
-      %-  return-error
-      %+  weld  "{<file-path>} build failed unexpectedly,"
-      " please see dojo for compilation errors"
-    ?:  ?=(%& -.result.update)
-      (return-success p.result.update)
-    =*  error
-      (reformat-compiler-error:zig-lib p.result.update)
-    %-  return-error
-    %+  weld  "{<file-path>} build failed: {<error>}"
-    " please see dojo for additional compilation errors"
-  =*  commit=@ta
-    ?~  commit-hash  %head  (scot %ux u.commit-hash)
-  =*  path-prefix=path
-   /(scot %p repo-host)/[desk-name]/[branch-name]/[commit]
-  ;<  jam-mar=(unit @t)  bind:m
-    %+  scry  (unit @t)
-    (welp [%gx %linedb path-prefix] /mar/jam/hoon/noun)
-  ?~  jam-mar
-    %-  return-error
-    %+  weld  "/mar/jam/hoon does not exist in %linedb"
-    " {<`path`path-prefix>}; please add and try again"
-  ;<  smart-lib-vase=vase  bind:m
-    (scry vase /gx/ziggurat/get-smart-lib-vase/noun)
-  ;<  =bowl:strand  bind:m  get-bowl
-  =*  zl  zig-lib(now.bowl now.bowl, our.bowl our.bowl)
-  =/  =build-result:zig
-    %^  build-contract:zl  smart-lib-vase  path-prefix
-    file-path
-  ?:  ?=(%| -.build-result)
-    %-  return-error
-    %+  weld
-      "contract compilation failed at {<`path`file-path>}"
-    " with error:\0a{<(trip p.build-result)>}"
-  =*  jam-path
-    (need (convert-contract-hoon-to-jam:zig-lib file-path))
-  ;<  empty-vase=vase  bind:m
-    %^  modify-file:zig-sys-threads  jam-path
-    `(jam p.build-result)  ~
-  ;<  ~  bind:m
-    %^  watch-our  /save-done  %linedb
-    [%branch-updates (snip path-prefix)]
-  ;<  ~  bind:m
-    %+  poke-our  %ziggurat
-    %^  make-read-repo-cage:zig-lib  project-name  desk-name
-    request-id
-  ;<  save-done=cage  bind:m  (take-fact /save-done)
-  ;<  ~  bind:m  (leave-our /save-done %linedb)
-  ?.  ?=(%linedb-update p.save-done)     !!
-  =+  !<(=update:linedb q.save-done)
-  ?.  ?=(%new-data -.update)             !!
-  ?.  =((snip path-prefix) path.update)  !!
-  (return-success !>(p.build-result))
+  (build:zig-sys-threads file-path ~)
 --


### PR DESCRIPTION
**Problem**:

Creating test threads, living in project repo, is annoying when importing new dev repos because the project repo likely lacks sur/lib files that would make writing those test threads easier/possible.

**Solution**:

1. Change %linedb %build to accept a list of repos, and try finding files in increasing index order. From %ziggurat side, when building something in project repo, pass in all dev repos in list as well. (implemented)
2. Add poke taking two repos and copying all shared files from one to the other -- establishing a "source of truth" ~~(forthcoming)~~ (implemented)

**Notes**:

Paired with https://github.com/uqbar-dao/linedb/pull/67

Done as of d376131